### PR TITLE
Handle extra cases in halting analysis

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  roots: ["<rootDir>/src"],
+  transform: {
+    "^.+\\.tsx?$": "ts-jest"
+  }
+};

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
-    "eject": "react-scripts eject"
+    "eject": "react-scripts eject",
+    "test:debugger": "node --inspect-brk node_modules/.bin/jest --runInBand --watch"
   },
   "eslintConfig": {
     "extends": "react-app"
@@ -43,6 +44,7 @@
   "devDependencies": {
     "husky": "^2.4.1",
     "prettier": "1.18.2",
-    "pretty-quick": "^1.11.0"
+    "pretty-quick": "^1.11.0",
+    "ts-jest": "^24.0.2"
   }
 }

--- a/src/Types/NetworkTypes.ts
+++ b/src/Types/NetworkTypes.ts
@@ -4,7 +4,7 @@ export type QuorumSet = {
   // Threshold, the number of validators that need to agree
   readonly t: number;
   // List of validators or subquorum sets
-  readonly v: string[] | QuorumSet[];
+  readonly v: (string | QuorumSet)[];
 };
 
 export type NetworkGraphNode = {
@@ -16,7 +16,7 @@ export type NetworkGraphNode = {
   // The identity of the validator
   readonly node: string;
   // Quorum set
-  readonly qset: QuorumSet;
+  readonly qset?: QuorumSet;
   // one of behind|tracking|ahead (compared to the root node) or missing|unknown (when there are no recent SCP messages for that node)
   readonly status: "behind" | "tracking" | "ahead" | "missing" | "unknown";
   // what the node is voting for

--- a/src/Types/NetworkTypes.ts
+++ b/src/Types/NetworkTypes.ts
@@ -15,7 +15,7 @@ export type NetworkGraphNode = {
   readonly heard: number;
   // The identity of the validator
   readonly node: string;
-  // Quorum set
+  // Quorum set.  Missing or unknown nodes will be undefined.
   readonly qset?: QuorumSet;
   // one of behind|tracking|ahead (compared to the root node) or missing|unknown (when there are no recent SCP messages for that node)
   readonly status: "behind" | "tracking" | "ahead" | "missing" | "unknown";

--- a/src/test/HaltingAnalysis.test.ts
+++ b/src/test/HaltingAnalysis.test.ts
@@ -6,6 +6,9 @@ import healthy from "./data/HealthyQuorum";
 import healthySubquorums from "./data/HealthySubquorums";
 import highlyDependent from "./data/HighlyDependent";
 import cyclical from "./data/CyclicalUnhealthy";
+import preHalt from "./data/PreHalt";
+import mixed from "./data/MixedQuorumType";
+import missing from "./data/MissingNodes";
 import {
   simple as simpleSubquorum,
   complex as complexSubquorum
@@ -72,6 +75,16 @@ describe("halting analysis", () => {
     expect(e.dependentsNames).toContain("b");
     expect(e.dependentsNames).toContain("c");
     expect(e.dependentsNames).toContain("d");
+  });
+
+  it("must handle topology with missing nodes", () => {
+    const failureCases = haltingAnalysis(missing);
+    expect(failureCases).toHaveLength(1);
+  });
+
+  it("must handle mixed type quorum sets", () => {
+    const failureCases = haltingAnalysis(mixed);
+    expect(failureCases).not.toHaveLength(0);
   });
 });
 

--- a/src/test/HaltingAnalysis.test.ts
+++ b/src/test/HaltingAnalysis.test.ts
@@ -6,7 +6,6 @@ import healthy from "./data/HealthyQuorum";
 import healthySubquorums from "./data/HealthySubquorums";
 import highlyDependent from "./data/HighlyDependent";
 import cyclical from "./data/CyclicalUnhealthy";
-import preHalt from "./data/PreHalt";
 import mixed from "./data/MixedQuorumType";
 import missing from "./data/MissingNodes";
 import {

--- a/src/test/data/MissingNodes.ts
+++ b/src/test/data/MissingNodes.ts
@@ -1,0 +1,16 @@
+import { NetworkGraphNode } from "../../Types/NetworkTypes";
+import { makeGraph } from "../util/makeNode";
+
+// A quorum in which one node is missing (and causes the graph to fail)
+const missing: NetworkGraphNode[] = makeGraph({
+  a: {
+    distance: 0,
+    qset: { t: 1, v: ["b"] }
+  },
+  b: {
+    qset: undefined,
+    status: "missing"
+  }
+});
+
+export default missing;

--- a/src/test/data/MixedQuorumType.ts
+++ b/src/test/data/MixedQuorumType.ts
@@ -1,0 +1,33 @@
+import { NetworkGraphNode } from "../../Types/NetworkTypes";
+import { makeGraph } from "../util/makeNode";
+
+// Some quorums can be lists of both nodes and subquorums
+const halfdead: NetworkGraphNode[] = makeGraph({
+  a: {
+    distance: 0,
+    qset: {
+      t: 3,
+      v: [
+        "b",
+        "c",
+        {
+          t: 1,
+          v: ["d"]
+        }
+      ]
+    }
+  },
+  b: {
+    qset: { t: 1, v: ["d"] }
+  },
+  c: {
+    qset: { t: 1, v: ["d"] }
+  },
+  d: {
+    qset: { t: 1, v: ["e"] }
+  },
+  e: {},
+  f: {}
+});
+
+export default halfdead;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2480,6 +2480,13 @@ browserslist@^4.0.0, browserslist@^4.1.1, browserslist@^4.4.2, browserslist@^4.5
     electron-to-chromium "^1.3.127"
     node-releases "^1.1.17"
 
+bs-logger@0.x:
+  version "0.2.6"
+  resolved "https://registry.yarnpkg.com/bs-logger/-/bs-logger-0.2.6.tgz#eb7d365307a72cf974cc6cda76b68354ad336bd8"
+  integrity sha512-pd8DCoxmbgc7hyPKOvxtqNcjYoOsABPQdcCUjGp3d42VR2CX1ORhk2A87oqqu5R1kk+76nsxZupkmyd+MVtCog==
+  dependencies:
+    fast-json-stable-stringify "2.x"
+
 bser@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/bser/-/bser-2.0.0.tgz#9ac78d3ed5d915804fd87acb158bc797147a1719"
@@ -2487,7 +2494,7 @@ bser@^2.0.0:
   dependencies:
     node-int64 "^0.4.0"
 
-buffer-from@^1.0.0:
+buffer-from@1.x, buffer-from@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.1.tgz#32713bc028f75c02fdb710d7c7bcec1f2c6070ef"
   integrity sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==
@@ -4418,7 +4425,7 @@ fast-glob@^2.0.2:
     merge2 "^1.2.3"
     micromatch "^3.1.10"
 
-fast-json-stable-stringify@^2.0.0:
+fast-json-stable-stringify@2.x, fast-json-stable-stringify@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz#d5142c0caee6b1189f87d3a76111064f86c8bbf2"
   integrity sha1-1RQsDK7msRifh9OnYREGT4bIu/I=
@@ -6249,17 +6256,17 @@ json3@^3.3.2:
   resolved "https://registry.yarnpkg.com/json3/-/json3-3.3.2.tgz#3c0434743df93e2f5c42aee7b19bcb483575f4e1"
   integrity sha1-PAQ0dD35Pi9cQq7nsZvLSDV19OE=
 
+json5@2.x, json5@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/json5/-/json5-2.1.0.tgz#e7a0c62c48285c628d20a10b85c89bb807c32850"
+  integrity sha512-8Mh9h6xViijj36g7Dxi+Y4S6hNGV96vcJZr/SrlHh1LR/pEn/8j/+qIBbs44YKl69Lrfctp4QD+AdWLTMqEZAQ==
+  dependencies:
+    minimist "^1.2.0"
+
 json5@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/json5/-/json5-1.0.1.tgz#779fb0018604fa854eacbf6252180d83543e3dbe"
   integrity sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==
-  dependencies:
-    minimist "^1.2.0"
-
-json5@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/json5/-/json5-2.1.0.tgz#e7a0c62c48285c628d20a10b85c89bb807c32850"
-  integrity sha512-8Mh9h6xViijj36g7Dxi+Y4S6hNGV96vcJZr/SrlHh1LR/pEn/8j/+qIBbs44YKl69Lrfctp4QD+AdWLTMqEZAQ==
   dependencies:
     minimist "^1.2.0"
 
@@ -6531,6 +6538,11 @@ make-dir@^2.0.0, make-dir@^2.1.0:
     pify "^4.0.1"
     semver "^5.6.0"
 
+make-error@1.x:
+  version "1.3.5"
+  resolved "https://registry.yarnpkg.com/make-error/-/make-error-1.3.5.tgz#efe4e81f6db28cadd605c70f29c831b58ef776c8"
+  integrity sha512-c3sIjNUow0+8swNwVpqoH4YCShKNFkMaw6oH1mNS2haDZQqkeZFlHS3dhoeEbKKmJB4vXpJucU6oH75aDYeE9g==
+
 makeerror@1.0.x:
   version "1.0.11"
   resolved "https://registry.yarnpkg.com/makeerror/-/makeerror-1.0.11.tgz#e01a5c9109f2af79660e4e8b9587790184f5a96c"
@@ -6781,7 +6793,7 @@ mixin-object@^2.0.1:
     for-in "^0.1.3"
     is-extendable "^0.1.1"
 
-mkdirp@0.5.1, mkdirp@0.5.x, mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5.0, mkdirp@~0.5.1:
+mkdirp@0.5.1, mkdirp@0.5.x, mkdirp@0.x, mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5.0, mkdirp@~0.5.1:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
   integrity sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=
@@ -8963,6 +8975,13 @@ resolve@1.10.0:
   dependencies:
     path-parse "^1.0.6"
 
+resolve@1.x:
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.11.1.tgz#ea10d8110376982fef578df8fc30b9ac30a07a3e"
+  integrity sha512-vIpgF6wfuJOZI7KKKSP+HmiKggadPQAdsp5HiC1mvqnfp0gF1vdwgBWZIdrVft9pgqoMFQN+R7BSWZiBxx+BBw==
+  dependencies:
+    path-parse "^1.0.6"
+
 resolve@^1.10.0, resolve@^1.3.2, resolve@^1.5.0, resolve@^1.8.1, resolve@^1.9.0:
   version "1.10.1"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.10.1.tgz#664842ac960795bbe758221cdccda61fb64b5f18"
@@ -9134,7 +9153,7 @@ semver-compare@^1.0.0:
   resolved "https://registry.yarnpkg.com/semver-compare/-/semver-compare-1.0.0.tgz#0dee216a1c941ab37e9efb1788f6afc5ff5537fc"
   integrity sha1-De4hahyUGrN+nvsXiPavxf9VN/w=
 
-"semver@2 || 3 || 4 || 5", semver@^5.3.0, semver@^5.4.1, semver@^5.5.0, semver@^5.5.1, semver@^5.6.0:
+"semver@2 || 3 || 4 || 5", semver@^5.3.0, semver@^5.4.1, semver@^5.5, semver@^5.5.0, semver@^5.5.1, semver@^5.6.0:
   version "5.7.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.0.tgz#790a7cf6fea5459bac96110b29b60412dc8ff96b"
   integrity sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==
@@ -9915,6 +9934,21 @@ trough@^1.0.0:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/trough/-/trough-1.0.3.tgz#e29bd1614c6458d44869fc28b255ab7857ef7c24"
   integrity sha512-fwkLWH+DimvA4YCy+/nvJd61nWQQ2liO/nF/RjkTpiOGi+zxZzVkhb1mvbHIIW4b/8nDsYI8uTmAlc0nNkRMOw==
+
+ts-jest@^24.0.2:
+  version "24.0.2"
+  resolved "https://registry.yarnpkg.com/ts-jest/-/ts-jest-24.0.2.tgz#8dde6cece97c31c03e80e474c749753ffd27194d"
+  integrity sha512-h6ZCZiA1EQgjczxq+uGLXQlNgeg02WWJBbeT8j6nyIBRQdglqbvzDoHahTEIiS6Eor6x8mK6PfZ7brQ9Q6tzHw==
+  dependencies:
+    bs-logger "0.x"
+    buffer-from "1.x"
+    fast-json-stable-stringify "2.x"
+    json5 "2.x"
+    make-error "1.x"
+    mkdirp "0.x"
+    resolve "1.x"
+    semver "^5.5"
+    yargs-parser "10.x"
 
 ts-pnp@1.1.2, ts-pnp@^1.0.0:
   version "1.1.2"
@@ -10725,7 +10759,7 @@ yallist@^3.0.0, yallist@^3.0.2:
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-3.0.3.tgz#b4b049e314be545e3ce802236d6cd22cd91c3de9"
   integrity sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==
 
-yargs-parser@^10.1.0:
+yargs-parser@10.x, yargs-parser@^10.1.0:
   version "10.1.0"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-10.1.0.tgz#7202265b89f7e9e9f2e5765e0fe735a905edbaa8"
   integrity sha512-VCIyR1wJoEBZUqk5PA+oOBF6ypbwh5aNB3I50guxAL/quggdfs4TtNHQrSazFA3fYZ+tEqfs0zIGlv0c/rgjbQ==


### PR DESCRIPTION
Need to handle cases:
- Mixed quorum sets, ie listing some direct nodes and some inner quorums
- Missing nodes, which will have no quorum set data and are already dead

Also make jest work with typescript and add a quick script to run it in chrome debugger `npm run test:debugger`