### PR TITLE
Check groups of node failures

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  roots: ["<rootDir>/src"],
+  transform: {
+    "^.+\\.tsx?$": "ts-jest"
+  }
+};

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
-    "eject": "react-scripts eject"
+    "eject": "react-scripts eject",
+    "test:debugger": "node --inspect-brk node_modules/.bin/jest --runInBand --watch"
   },
   "eslintConfig": {
     "extends": "react-app"
@@ -43,6 +44,7 @@
   "devDependencies": {
     "husky": "^2.4.1",
     "prettier": "1.18.2",
-    "pretty-quick": "^1.11.0"
+    "pretty-quick": "^1.11.0",
+    "ts-jest": "^24.0.2"
   }
 }

--- a/src/Types/NetworkTypes.ts
+++ b/src/Types/NetworkTypes.ts
@@ -12,7 +12,7 @@ export type NetworkGraphNode = {
   // 0 means this is the node being administrated
   readonly distance: number;
   // The latest ledger sequence number that this node voted at
-  readonly heard: number;
+  readonly heard?: number;
   // The identity of the validator
   readonly node: string;
   // Quorum set.  Missing or unknown nodes will be undefined.
@@ -20,7 +20,7 @@ export type NetworkGraphNode = {
   // one of behind|tracking|ahead (compared to the root node) or missing|unknown (when there are no recent SCP messages for that node)
   readonly status: "behind" | "tracking" | "ahead" | "missing" | "unknown";
   // what the node is voting for
-  readonly value: string;
+  readonly value?: string;
   // a unique ID for what the node is voting for (allows to quickly tell if nodes are voting for the same thing)
-  readonly value_id: number;
+  readonly value_id?: number;
 };

--- a/src/Types/NetworkTypes.ts
+++ b/src/Types/NetworkTypes.ts
@@ -4,7 +4,7 @@ export type QuorumSet = {
   // Threshold, the number of validators that need to agree
   readonly t: number;
   // List of validators or subquorum sets
-  readonly v: string[] | QuorumSet[];
+  readonly v: (string | QuorumSet)[];
 };
 
 export type NetworkGraphNode = {
@@ -15,8 +15,8 @@ export type NetworkGraphNode = {
   readonly heard: number;
   // The identity of the validator
   readonly node: string;
-  // Quorum set
-  readonly qset: QuorumSet;
+  // Quorum set.  Missing or unknown nodes will be undefined.
+  readonly qset?: QuorumSet;
   // one of behind|tracking|ahead (compared to the root node) or missing|unknown (when there are no recent SCP messages for that node)
   readonly status: "behind" | "tracking" | "ahead" | "missing" | "unknown";
   // what the node is voting for

--- a/src/d3/ForceGraph.tsx
+++ b/src/d3/ForceGraph.tsx
@@ -157,8 +157,8 @@ const ForceGraph = (
 
   nodeGroup
     .select(".node.self")
-    // @ts-ignore this possibly being null.  We will always have a self node.
     .select(function() {
+      // @ts-ignore this possibly being null.  We will always have a self node.
       return this.parentNode;
     })
     .append("text")

--- a/src/test/HaltingAnalysis.test.ts
+++ b/src/test/HaltingAnalysis.test.ts
@@ -1,6 +1,7 @@
 import {
   haltingAnalysis,
-  createAnalysisStructure
+  createAnalysisStructure,
+  generateCombinations
 } from "../util/HaltingAnalysis";
 import healthy from "./data/HealthyQuorum";
 import healthySubquorums from "./data/HealthySubquorums";
@@ -8,6 +9,7 @@ import highlyDependent from "./data/HighlyDependent";
 import cyclical from "./data/CyclicalUnhealthy";
 import mixed from "./data/MixedQuorumType";
 import missing from "./data/MissingNodes";
+import twonode from "./data/TwoNodeFailure";
 import {
   simple as simpleSubquorum,
   complex as complexSubquorum
@@ -84,6 +86,17 @@ describe("halting analysis", () => {
   it("must handle mixed type quorum sets", () => {
     const failureCases = haltingAnalysis(mixed);
     expect(failureCases).not.toHaveLength(0);
+  });
+
+  it("must find failure cases for 2 node vulnerabilities", () => {
+    const fc = haltingAnalysis(twonode, 2);
+    expect(fc).toHaveLength(1);
+  });
+
+  it("must generate correct subsets for n>1 groups", () => {
+    const nodes = ["a", "b", "c", "d", "e"];
+    const sets = generateCombinations(nodes, 3);
+    expect(sets).toHaveLength(25); // 5choose3 + 5choose2 + 5choose1 = 10 + 10 + 5
   });
 });
 

--- a/src/test/HaltingAnalysis.test.ts
+++ b/src/test/HaltingAnalysis.test.ts
@@ -6,6 +6,8 @@ import healthy from "./data/HealthyQuorum";
 import healthySubquorums from "./data/HealthySubquorums";
 import highlyDependent from "./data/HighlyDependent";
 import cyclical from "./data/CyclicalUnhealthy";
+import mixed from "./data/MixedQuorumType";
+import missing from "./data/MissingNodes";
 import {
   simple as simpleSubquorum,
   complex as complexSubquorum
@@ -72,6 +74,16 @@ describe("halting analysis", () => {
     expect(e.dependentsNames).toContain("b");
     expect(e.dependentsNames).toContain("c");
     expect(e.dependentsNames).toContain("d");
+  });
+
+  it("must handle topology with missing nodes", () => {
+    const failureCases = haltingAnalysis(missing);
+    expect(failureCases).toHaveLength(1);
+  });
+
+  it("must handle mixed type quorum sets", () => {
+    const failureCases = haltingAnalysis(mixed);
+    expect(failureCases).not.toHaveLength(0);
   });
 });
 

--- a/src/test/data/Halted.ts
+++ b/src/test/data/Halted.ts
@@ -1,0 +1,1053 @@
+export default [
+  {
+    distance: 0,
+    heard: 23869397,
+    node: "GAYTO",
+    qset: {
+      t: 2,
+      v: ["SDF_validator_1", "SDF_validator_2", "SDF_validator_3"]
+    },
+    status: "tracking",
+    value: "[ txH: f14f54, ct: 1557951246, upgrades: [ ] ]",
+    value_id: 1
+  },
+  {
+    distance: 1,
+    heard: 23869397,
+    node: "SDF_validator_3",
+    qset: {
+      t: 5,
+      v: [
+        "SDF_validator_3",
+        "SDF_validator_1",
+        "SDF_validator_2",
+        "LOBSTR_2__Europe_",
+        "Eno",
+        "umbrel",
+        "keybase_io",
+        "COINQVEST__Germany_",
+        {
+          t: 2,
+          v: [
+            "SatoshiPay__DE__Frankfurt_",
+            "SatoshiPay__SG__Singapore_",
+            "SatoshiPay__US__Iowa_"
+          ]
+        }
+      ]
+    },
+    status: "tracking",
+    value: "[ txH: f14f54, ct: 1557951246, upgrades: [ ] ]",
+    value_id: 1
+  },
+  {
+    distance: 1,
+    heard: 23869397,
+    node: "SDF_validator_1",
+    qset: {
+      t: 5,
+      v: [
+        "SDF_validator_2",
+        "SDF_validator_3",
+        "Eno",
+        "LOBSTR_1__Europe_",
+        "keybase_io",
+        "umbrel",
+        "COINQVEST__Germany_",
+        {
+          t: 2,
+          v: ["Wirex_United_States", "Wirex_Singapore", "Wirex_United_Kingdom"]
+        },
+        {
+          t: 2,
+          v: [
+            "SatoshiPay__DE__Frankfurt_",
+            "SatoshiPay__SG__Singapore_",
+            "SatoshiPay__US__Iowa_"
+          ]
+        }
+      ]
+    },
+    status: "tracking",
+    value: "[ txH: f14f54, ct: 1557951246, upgrades: [ ] ]",
+    value_id: 1
+  },
+  {
+    distance: 1,
+    heard: 23869397,
+    node: "SDF_validator_2",
+    qset: {
+      t: 5,
+      v: [
+        "SDF_validator_3",
+        "SDF_validator_1",
+        "SDF_validator_2",
+        "LOBSTR_2__Europe_",
+        "Eno",
+        "umbrel",
+        "keybase_io",
+        "COINQVEST__Finland_",
+        {
+          t: 2,
+          v: [
+            "SatoshiPay__DE__Frankfurt_",
+            "SatoshiPay__SG__Singapore_",
+            "SatoshiPay__US__Iowa_"
+          ]
+        }
+      ]
+    },
+    status: "tracking",
+    value: "[ txH: f14f54, ct: 1557951246, upgrades: [ ] ]",
+    value_id: 1
+  },
+  {
+    distance: 2,
+    node: "Wirex_Singapore",
+    status: "missing"
+  },
+  {
+    distance: 2,
+    heard: 23869397,
+    node: "COINQVEST__Finland_",
+    qset: {
+      t: 6,
+      v: [
+        "COINQVEST__Germany_",
+        "COINQVEST__Finland_",
+        "keybase_io",
+        "LOBSTR_2__Europe_",
+        "Eno",
+        "umbrel",
+        {
+          t: 2,
+          v: [
+            "SatoshiPay__DE__Frankfurt_",
+            "SatoshiPay__SG__Singapore_",
+            "SatoshiPay__US__Iowa_"
+          ]
+        },
+        {
+          t: 2,
+          v: ["SDF_validator_1", "SDF_validator_2", "SDF_validator_3"]
+        }
+      ]
+    },
+    status: "tracking",
+    value: "[ txH: f14f54, ct: 1557951246, upgrades: [ ] ]",
+    value_id: 1
+  },
+  {
+    distance: 2,
+    heard: 23869397,
+    node: "SatoshiPay__US__Iowa_",
+    qset: {
+      t: 5,
+      v: [
+        "COINQVEST__Germany_",
+        "LOBSTR_1__Europe_",
+        "SatoshiPay__DE__Frankfurt_",
+        "SatoshiPay__SG__Singapore_",
+        "SatoshiPay__US__Iowa_",
+        "umbrel",
+        {
+          t: 2,
+          v: ["SDF_validator_1", "SDF_validator_2", "SDF_validator_3"]
+        }
+      ]
+    },
+    status: "tracking",
+    value: "[ txH: f14f54, ct: 1557951246, upgrades: [ ] ]",
+    value_id: 1
+  },
+  {
+    distance: 2,
+    heard: 23869397,
+    node: "Eno",
+    qset: {
+      t: 6,
+      v: [
+        "keybase_io",
+        "LOBSTR_2__Europe_",
+        "COINQVEST__Germany_",
+        "Eno",
+        "umbrel",
+        "IBM_Australia",
+        {
+          t: 2,
+          v: ["Wirex_United_States", "Wirex_Singapore", "Wirex_United_Kingdom"]
+        },
+        {
+          t: 2,
+          v: ["SDF_validator_1", "SDF_validator_2", "SDF_validator_3"]
+        },
+        {
+          t: 2,
+          v: [
+            "SatoshiPay__DE__Frankfurt_",
+            "SatoshiPay__SG__Singapore_",
+            "SatoshiPay__US__Iowa_"
+          ]
+        }
+      ]
+    },
+    status: "tracking",
+    value: "[ txH: f14f54, ct: 1557951246, upgrades: [ ] ]",
+    value_id: 1
+  },
+  {
+    distance: 2,
+    heard: 23869397,
+    node: "Wirex_United_Kingdom",
+    qset: {
+      t: 7,
+      v: [
+        "keybase_io",
+        "LOBSTR_2__Europe_",
+        "Eno",
+        "umbrel",
+        "Wirex_United_States",
+        "Wirex_Singapore",
+        "Wirex_United_Kingdom",
+        {
+          t: 2,
+          v: ["SDF_validator_1", "SDF_validator_2", "SDF_validator_3"]
+        },
+        {
+          t: 2,
+          v: [
+            "SatoshiPay__DE__Frankfurt_",
+            "SatoshiPay__SG__Singapore_",
+            "SatoshiPay__US__Iowa_"
+          ]
+        }
+      ]
+    },
+    status: "tracking",
+    value: "[ txH: f14f54, ct: 1557951246, upgrades: [ ] ]",
+    value_id: 1
+  },
+  {
+    distance: 2,
+    heard: 23869397,
+    node: "SatoshiPay__SG__Singapore_",
+    qset: {
+      t: 5,
+      v: [
+        "COINQVEST__Germany_",
+        "LOBSTR_1__Europe_",
+        "SatoshiPay__DE__Frankfurt_",
+        "SatoshiPay__SG__Singapore_",
+        "SatoshiPay__US__Iowa_",
+        "umbrel",
+        {
+          t: 2,
+          v: ["SDF_validator_1", "SDF_validator_2", "SDF_validator_3"]
+        }
+      ]
+    },
+    status: "tracking",
+    value: "[ txH: f14f54, ct: 1557951246, upgrades: [ ] ]",
+    value_id: 1
+  },
+  {
+    distance: 2,
+    heard: 23869397,
+    node: "LOBSTR_1__Europe_",
+    qset: {
+      t: 7,
+      v: [
+        "LOBSTR_1__Europe_",
+        "LOBSTR_2__Europe_",
+        "keybase_io",
+        "COINQVEST__Germany_",
+        "Eno",
+        "umbrel",
+        {
+          t: 2,
+          v: ["Sakkex_Germany", "Sakkex_Singapore", "Sakkex_United_Kingdom"]
+        },
+        {
+          t: 2,
+          v: ["SDF_validator_1", "SDF_validator_2", "SDF_validator_3"]
+        },
+        {
+          t: 2,
+          v: ["Wirex_United_States", "Wirex_Singapore", "Wirex_United_Kingdom"]
+        },
+        {
+          t: 2,
+          v: [
+            "SatoshiPay__DE__Frankfurt_",
+            "SatoshiPay__SG__Singapore_",
+            "SatoshiPay__US__Iowa_"
+          ]
+        }
+      ]
+    },
+    status: "tracking",
+    value: "[ txH: f14f54, ct: 1557951246, upgrades: [ ] ]",
+    value_id: 1
+  },
+  {
+    distance: 2,
+    heard: 23869398,
+    node: "keybase_io",
+    qset: {
+      t: 5,
+      v: [
+        "LOBSTR_2__Europe_",
+        "COINQVEST__Germany_",
+        "Eno",
+        "umbrel",
+        "IBM_Australia",
+        {
+          t: 2,
+          v: ["Sakkex_Germany", "Sakkex_Singapore", "Sakkex_United_Kingdom"]
+        },
+        {
+          t: 2,
+          v: ["Wirex_United_States", "Wirex_Singapore", "Wirex_United_Kingdom"]
+        },
+        {
+          t: 2,
+          v: [
+            "SatoshiPay__DE__Frankfurt_",
+            "SatoshiPay__SG__Singapore_",
+            "SatoshiPay__US__Iowa_"
+          ]
+        }
+      ]
+    },
+    status: "ahead",
+    value: "[ txH: cce617, ct: 1557951360, upgrades: [ ] ]",
+    value_id: 12
+  },
+  {
+    distance: 2,
+    heard: 23869397,
+    node: "SatoshiPay__DE__Frankfurt_",
+    qset: {
+      t: 5,
+      v: [
+        "COINQVEST__Germany_",
+        "LOBSTR_1__Europe_",
+        "SatoshiPay__DE__Frankfurt_",
+        "SatoshiPay__SG__Singapore_",
+        "SatoshiPay__US__Iowa_",
+        "umbrel",
+        {
+          t: 2,
+          v: ["SDF_validator_1", "SDF_validator_2", "SDF_validator_3"]
+        }
+      ]
+    },
+    status: "tracking",
+    value: "[ txH: f14f54, ct: 1557951246, upgrades: [ ] ]",
+    value_id: 1
+  },
+  {
+    distance: 2,
+    heard: 23869397,
+    node: "LOBSTR_2__Europe_",
+    qset: {
+      t: 7,
+      v: [
+        "LOBSTR_1__Europe_",
+        "LOBSTR_2__Europe_",
+        "keybase_io",
+        "COINQVEST__Germany_",
+        "Eno",
+        "umbrel",
+        {
+          t: 2,
+          v: ["Sakkex_Germany", "Sakkex_Singapore", "Sakkex_United_Kingdom"]
+        },
+        {
+          t: 2,
+          v: ["SDF_validator_1", "SDF_validator_2", "SDF_validator_3"]
+        },
+        {
+          t: 2,
+          v: ["Wirex_United_States", "Wirex_Singapore", "Wirex_United_Kingdom"]
+        },
+        {
+          t: 2,
+          v: [
+            "SatoshiPay__DE__Frankfurt_",
+            "SatoshiPay__SG__Singapore_",
+            "SatoshiPay__US__Iowa_"
+          ]
+        }
+      ]
+    },
+    status: "tracking",
+    value: "[ txH: f14f54, ct: 1557951246, upgrades: [ ] ]",
+    value_id: 1
+  },
+  {
+    distance: 2,
+    heard: 23869397,
+    node: "Wirex_United_States",
+    qset: {
+      t: 7,
+      v: [
+        "keybase_io",
+        "LOBSTR_2__Europe_",
+        "Eno",
+        "umbrel",
+        "Wirex_United_States",
+        "Wirex_Singapore",
+        "Wirex_United_Kingdom",
+        {
+          t: 2,
+          v: ["SDF_validator_1", "SDF_validator_2", "SDF_validator_3"]
+        },
+        {
+          t: 2,
+          v: [
+            "SatoshiPay__DE__Frankfurt_",
+            "SatoshiPay__SG__Singapore_",
+            "SatoshiPay__US__Iowa_"
+          ]
+        }
+      ]
+    },
+    status: "tracking",
+    value: "[ txH: f14f54, ct: 1557951246, upgrades: [ ] ]",
+    value_id: 1
+  },
+  {
+    distance: 2,
+    heard: 23869397,
+    node: "COINQVEST__Germany_",
+    qset: {
+      t: 6,
+      v: [
+        "COINQVEST__Germany_",
+        "COINQVEST__Finland_",
+        "keybase_io",
+        "LOBSTR_2__Europe_",
+        "Eno",
+        "umbrel",
+        {
+          t: 2,
+          v: [
+            "SatoshiPay__DE__Frankfurt_",
+            "SatoshiPay__SG__Singapore_",
+            "SatoshiPay__US__Iowa_"
+          ]
+        },
+        {
+          t: 2,
+          v: ["SDF_validator_1", "SDF_validator_2", "SDF_validator_3"]
+        }
+      ]
+    },
+    status: "tracking",
+    value: "[ txH: f14f54, ct: 1557951246, upgrades: [ ] ]",
+    value_id: 1
+  },
+  {
+    distance: 2,
+    node: "umbrel",
+    qset: {
+      t: 7,
+      v: [
+        "Eno",
+        "LOBSTR_2__Europe_",
+        "IBM_Australia",
+        "keybase_io",
+        "COINQVEST__Germany_",
+        "stellar_sui_li",
+        {
+          t: 2,
+          v: ["Sakkex_Germany", "Sakkex_Singapore", "Sakkex_United_Kingdom"]
+        },
+        {
+          t: 2,
+          v: ["Wirex_United_States", "Wirex_United_Kingdom", "Wirex_Singapore"]
+        },
+        {
+          t: 2,
+          v: [
+            "SatoshiPay__DE__Frankfurt_",
+            "SatoshiPay__SG__Singapore_",
+            "SatoshiPay__US__Iowa_"
+          ]
+        },
+        {
+          t: 2,
+          v: ["SDF_validator_1", "SDF_validator_2", "SDF_validator_3"]
+        }
+      ]
+    },
+    status: "missing"
+  },
+  {
+    distance: 3,
+    heard: 23869397,
+    node: "stellar_sui_li",
+    qset: {
+      t: 7,
+      v: [
+        "Tempo",
+        "keybase_io",
+        "Eno",
+        "umbrel",
+        "COINQVEST__Germany_",
+        "smoove_net_1",
+        "numerotron",
+        {
+          t: 2,
+          v: ["IBM_United_Kingdom", "IBM_Italy", "IBM_Hong_Kong"]
+        },
+        {
+          t: 2,
+          v: ["Wirex_United_States", "Wirex_Singapore", "Wirex_United_Kingdom"]
+        },
+        {
+          t: 2,
+          v: [
+            "SatoshiPay__DE__Frankfurt_",
+            "SatoshiPay__SG__Singapore_",
+            "SatoshiPay__US__Iowa_"
+          ]
+        }
+      ]
+    },
+    status: "tracking",
+    value: "[ txH: f14f54, ct: 1557951246, upgrades: [ ] ]",
+    value_id: 1
+  },
+  {
+    distance: 3,
+    node: "Sakkex_Germany",
+    status: "missing"
+  },
+  {
+    distance: 3,
+    heard: 23869397,
+    node: "IBM_Australia",
+    qset: {
+      t: 3,
+      v: [
+        "keybase_io",
+        "LOBSTR_2__Europe_",
+        "Eno",
+        {
+          t: 2,
+          v: ["SDF_validator_1", "SDF_validator_2", "SDF_validator_3"]
+        },
+        {
+          t: 2,
+          v: [
+            "SatoshiPay__DE__Frankfurt_",
+            "SatoshiPay__SG__Singapore_",
+            "SatoshiPay__US__Iowa_"
+          ]
+        }
+      ]
+    },
+    status: "tracking",
+    value: "[ txH: f14f54, ct: 1557951246, upgrades: [ ] ]",
+    value_id: 1
+  },
+  {
+    distance: 3,
+    node: "Sakkex_United_Kingdom",
+    status: "missing"
+  },
+  {
+    distance: 3,
+    node: "Sakkex_Singapore",
+    status: "missing"
+  },
+  {
+    distance: 4,
+    heard: 23869397,
+    node: "IBM_Italy",
+    qset: {
+      t: 5,
+      v: [
+        "keybase_io",
+        "LOBSTR_2__Europe_",
+        "Eno",
+        "umbrel",
+        {
+          t: 2,
+          v: [
+            "SatoshiPay__DE__Frankfurt_",
+            "SatoshiPay__SG__Singapore_",
+            "SatoshiPay__US__Iowa_"
+          ]
+        },
+        {
+          t: 2,
+          v: ["SDF_validator_1", "SDF_validator_2", "SDF_validator_3"]
+        },
+        {
+          t: 5,
+          v: [
+            "IBM_Australia",
+            "IBM_Brazil",
+            "IBM_Canada",
+            "IBM_Norway",
+            "IBM_India",
+            "IBM_Hong_Kong",
+            "IBM_United_Kingdom",
+            "IBM_United_States"
+          ]
+        }
+      ]
+    },
+    status: "tracking",
+    value: "[ txH: f14f54, ct: 1557951246, upgrades: [ ] ]",
+    value_id: 1
+  },
+  {
+    distance: 4,
+    heard: 23869397,
+    node: "IBM_United_Kingdom",
+    qset: {
+      t: 5,
+      v: [
+        "keybase_io",
+        "LOBSTR_2__Europe_",
+        "Eno",
+        "umbrel",
+        {
+          t: 2,
+          v: [
+            "SatoshiPay__DE__Frankfurt_",
+            "SatoshiPay__SG__Singapore_",
+            "SatoshiPay__US__Iowa_"
+          ]
+        },
+        {
+          t: 2,
+          v: ["SDF_validator_1", "SDF_validator_2", "SDF_validator_3"]
+        },
+        {
+          t: 5,
+          v: [
+            "IBM_Australia",
+            "IBM_Brazil",
+            "IBM_Canada",
+            "IBM_Italy",
+            "IBM_India",
+            "IBM_Hong_Kong",
+            "IBM_Norway",
+            "IBM_United_States"
+          ]
+        }
+      ]
+    },
+    status: "tracking",
+    value: "[ txH: f14f54, ct: 1557951246, upgrades: [ ] ]",
+    value_id: 1
+  },
+  {
+    distance: 4,
+    node: "IBM_Hong_Kong",
+    qset: {
+      t: 5,
+      v: [
+        "keybase_io",
+        "LOBSTR_2__Europe_",
+        "Eno",
+        "umbrel",
+        {
+          t: 2,
+          v: [
+            "SatoshiPay__DE__Frankfurt_",
+            "SatoshiPay__SG__Singapore_",
+            "SatoshiPay__US__Iowa_"
+          ]
+        },
+        {
+          t: 2,
+          v: ["SDF_validator_1", "SDF_validator_2", "SDF_validator_3"]
+        },
+        {
+          t: 5,
+          v: [
+            "IBM_Australia",
+            "IBM_Brazil",
+            "IBM_Norway",
+            "IBM_Italy",
+            "IBM_Canada",
+            "IBM_India",
+            "IBM_United_Kingdom",
+            "IBM_United_States"
+          ]
+        }
+      ]
+    },
+    status: "missing"
+  },
+  {
+    distance: 4,
+    heard: 23869397,
+    node: "Tempo",
+    qset: {
+      t: 4,
+      v: [
+        "SDF_validator_2",
+        "SDF_validator_1",
+        "Tempo",
+        "Eno",
+        "SDF_validator_3"
+      ]
+    },
+    status: "tracking",
+    value: "[ txH: f14f54, ct: 1557951246, upgrades: [ ] ]",
+    value_id: 1
+  },
+  {
+    distance: 4,
+    heard: 23869397,
+    node: "numerotron",
+    qset: {
+      t: 6,
+      v: [
+        "keybase_io",
+        "LOBSTR_2__Europe_",
+        "COINQVEST__Germany_",
+        "Eno",
+        "umbrel",
+        "IBM_Australia",
+        {
+          t: 2,
+          v: ["Sakkex_Germany", "Sakkex_Singapore", "Sakkex_United_Kingdom"]
+        },
+        {
+          t: 2,
+          v: ["Wirex_United_States", "Wirex_Singapore", "Wirex_United_Kingdom"]
+        },
+        {
+          t: 2,
+          v: [
+            "SatoshiPay__DE__Frankfurt_",
+            "SatoshiPay__SG__Singapore_",
+            "SatoshiPay__US__Iowa_"
+          ]
+        }
+      ]
+    },
+    status: "tracking",
+    value: "[ txH: f14f54, ct: 1557951246, upgrades: [ ] ]",
+    value_id: 1
+  },
+  {
+    distance: 4,
+    heard: 23869397,
+    node: "smoove_net_1",
+    qset: {
+      t: 5,
+      v: [
+        "keybase_io",
+        "Smartlands_Platform",
+        "smoove_net_1",
+        "stellar_sui_li",
+        "umbrel",
+        {
+          t: 3,
+          v: [
+            "IBM_United_States",
+            "LOBSTR_1__Europe_",
+            "Stellarport_Ohio_1",
+            "Tyler_Vault__Texas",
+            "Wirex_United_States"
+          ]
+        },
+        {
+          t: 3,
+          v: [
+            "COINQVEST__Finland_",
+            "COINQVEST__Germany_",
+            "SatoshiPay__DE__Frankfurt_",
+            "SatoshiPay__SG__Singapore_",
+            "SatoshiPay__US__Iowa_"
+          ]
+        }
+      ]
+    },
+    status: "tracking",
+    value: "[ txH: f14f54, ct: 1557951246, upgrades: [ ] ]",
+    value_id: 1
+  },
+  {
+    distance: 5,
+    heard: 23869397,
+    node: "IBM_United_States",
+    qset: {
+      t: 5,
+      v: [
+        "keybase_io",
+        "LOBSTR_2__Europe_",
+        "Eno",
+        "umbrel",
+        {
+          t: 2,
+          v: [
+            "SatoshiPay__DE__Frankfurt_",
+            "SatoshiPay__SG__Singapore_",
+            "SatoshiPay__US__Iowa_"
+          ]
+        },
+        {
+          t: 2,
+          v: ["SDF_validator_1", "SDF_validator_2", "SDF_validator_3"]
+        },
+        {
+          t: 5,
+          v: [
+            "IBM_Australia",
+            "IBM_Brazil",
+            "IBM_Canada",
+            "IBM_Italy",
+            "IBM_India",
+            "IBM_Hong_Kong",
+            "IBM_Norway",
+            "IBM_United_Kingdom"
+          ]
+        }
+      ]
+    },
+    status: "tracking",
+    value: "[ txH: f14f54, ct: 1557951246, upgrades: [ ] ]",
+    value_id: 1
+  },
+  {
+    distance: 5,
+    heard: 23869397,
+    node: "Tyler_Vault__Texas",
+    qset: {
+      t: 4,
+      v: [
+        "SDF_validator_1",
+        "Eno",
+        "Tempo",
+        "SDF_validator_2",
+        "SDF_validator_3"
+      ]
+    },
+    status: "tracking",
+    value: "[ txH: f14f54, ct: 1557951246, upgrades: [ ] ]",
+    value_id: 1
+  },
+  {
+    distance: 5,
+    heard: 23869397,
+    node: "Stellarport_Ohio_1",
+    qset: {
+      t: 4,
+      v: [
+        "SDF_validator_1",
+        "SDF_validator_2",
+        "SDF_validator_3",
+        "SatoshiPay__US__Iowa_",
+        "Eno",
+        "Tempo"
+      ]
+    },
+    status: "tracking",
+    value: "[ txH: f14f54, ct: 1557951246, upgrades: [ ] ]",
+    value_id: 1
+  },
+  {
+    distance: 5,
+    heard: 23869397,
+    node: "IBM_Brazil",
+    qset: {
+      t: 5,
+      v: [
+        "keybase_io",
+        "LOBSTR_2__Europe_",
+        "Eno",
+        "umbrel",
+        {
+          t: 2,
+          v: [
+            "SatoshiPay__DE__Frankfurt_",
+            "SatoshiPay__SG__Singapore_",
+            "SatoshiPay__US__Iowa_"
+          ]
+        },
+        {
+          t: 2,
+          v: ["SDF_validator_1", "SDF_validator_2", "SDF_validator_3"]
+        },
+        {
+          t: 5,
+          v: [
+            "IBM_Australia",
+            "IBM_Canada",
+            "IBM_Norway",
+            "IBM_Italy",
+            "IBM_Hong_Kong",
+            "IBM_India",
+            "IBM_United_Kingdom",
+            "IBM_United_States"
+          ]
+        }
+      ]
+    },
+    status: "tracking",
+    value: "[ txH: f14f54, ct: 1557951246, upgrades: [ ] ]",
+    value_id: 1
+  },
+  {
+    distance: 5,
+    heard: 23869397,
+    node: "IBM_Canada",
+    qset: {
+      t: 5,
+      v: [
+        "keybase_io",
+        "LOBSTR_2__Europe_",
+        "Eno",
+        "umbrel",
+        {
+          t: 2,
+          v: [
+            "SatoshiPay__DE__Frankfurt_",
+            "SatoshiPay__SG__Singapore_",
+            "SatoshiPay__US__Iowa_"
+          ]
+        },
+        {
+          t: 2,
+          v: ["SDF_validator_1", "SDF_validator_2", "SDF_validator_3"]
+        },
+        {
+          t: 5,
+          v: [
+            "IBM_Australia",
+            "IBM_Brazil",
+            "IBM_Norway",
+            "IBM_Italy",
+            "IBM_Hong_Kong",
+            "IBM_India",
+            "IBM_United_Kingdom",
+            "IBM_United_States"
+          ]
+        }
+      ]
+    },
+    status: "tracking",
+    value: "[ txH: f14f54, ct: 1557951246, upgrades: [ ] ]",
+    value_id: 1
+  },
+  {
+    distance: 5,
+    heard: 23869397,
+    node: "Smartlands_Platform",
+    qset: {
+      t: 6,
+      v: [
+        "GDIQK",
+        "Eno",
+        "Tempo",
+        "SatoshiPay__DE__Frankfurt_",
+        "umbrel",
+        "SDF_validator_1",
+        "SDF_validator_2",
+        "SDF_validator_3"
+      ]
+    },
+    status: "tracking",
+    value: "[ txH: f14f54, ct: 1557951246, upgrades: [ ] ]",
+    value_id: 1
+  },
+  {
+    distance: 5,
+    heard: 23869397,
+    node: "IBM_India",
+    qset: {
+      t: 5,
+      v: [
+        "keybase_io",
+        "LOBSTR_2__Europe_",
+        "Eno",
+        "umbrel",
+        {
+          t: 2,
+          v: [
+            "SatoshiPay__DE__Frankfurt_",
+            "SatoshiPay__SG__Singapore_",
+            "SatoshiPay__US__Iowa_"
+          ]
+        },
+        {
+          t: 2,
+          v: ["SDF_validator_1", "SDF_validator_2", "SDF_validator_3"]
+        },
+        {
+          t: 5,
+          v: [
+            "IBM_Australia",
+            "IBM_Brazil",
+            "IBM_Canada",
+            "IBM_Norway",
+            "IBM_Italy",
+            "IBM_Hong_Kong",
+            "IBM_United_Kingdom",
+            "IBM_United_States"
+          ]
+        }
+      ]
+    },
+    status: "tracking",
+    value: "[ txH: f14f54, ct: 1557951246, upgrades: [ ] ]",
+    value_id: 1
+  },
+  {
+    distance: 5,
+    heard: 23869397,
+    node: "IBM_Norway",
+    qset: {
+      t: 5,
+      v: [
+        "keybase_io",
+        "LOBSTR_2__Europe_",
+        "Eno",
+        "umbrel",
+        {
+          t: 2,
+          v: [
+            "SatoshiPay__DE__Frankfurt_",
+            "SatoshiPay__SG__Singapore_",
+            "SatoshiPay__US__Iowa_"
+          ]
+        },
+        {
+          t: 2,
+          v: ["SDF_validator_1", "SDF_validator_2", "SDF_validator_3"]
+        },
+        {
+          t: 5,
+          v: [
+            "IBM_Australia",
+            "IBM_Brazil",
+            "IBM_Canada",
+            "IBM_Italy",
+            "IBM_India",
+            "IBM_Hong_Kong",
+            "IBM_United_Kingdom",
+            "IBM_United_States"
+          ]
+        }
+      ]
+    },
+    status: "tracking",
+    value: "[ txH: f14f54, ct: 1557951246, upgrades: [ ] ]",
+    value_id: 1
+  },
+  {
+    distance: 6,
+    node: "GDIQK",
+    status: "missing"
+  }
+];

--- a/src/test/data/MissingNodes.ts
+++ b/src/test/data/MissingNodes.ts
@@ -1,0 +1,16 @@
+import { NetworkGraphNode } from "../../Types/NetworkTypes";
+import { makeGraph } from "../util/makeNode";
+
+// A quorum in which one node is missing (and causes the graph to fail)
+const missing: NetworkGraphNode[] = makeGraph({
+  a: {
+    distance: 0,
+    qset: { t: 1, v: ["b"] }
+  },
+  b: {
+    qset: undefined,
+    status: "missing"
+  }
+});
+
+export default missing;

--- a/src/test/data/MixedQuorumType.ts
+++ b/src/test/data/MixedQuorumType.ts
@@ -1,0 +1,33 @@
+import { NetworkGraphNode } from "../../Types/NetworkTypes";
+import { makeGraph } from "../util/makeNode";
+
+// Some quorums can be lists of both nodes and subquorums
+const halfdead: NetworkGraphNode[] = makeGraph({
+  a: {
+    distance: 0,
+    qset: {
+      t: 3,
+      v: [
+        "b",
+        "c",
+        {
+          t: 1,
+          v: ["d"]
+        }
+      ]
+    }
+  },
+  b: {
+    qset: { t: 1, v: ["d"] }
+  },
+  c: {
+    qset: { t: 1, v: ["d"] }
+  },
+  d: {
+    qset: { t: 1, v: ["e"] }
+  },
+  e: {},
+  f: {}
+});
+
+export default halfdead;

--- a/src/test/data/PreHalt.ts
+++ b/src/test/data/PreHalt.ts
@@ -1,0 +1,1803 @@
+import { NetworkGraphNode } from "../../Types/NetworkTypes";
+
+const nodes: NetworkGraphNode[] = [
+  {
+    distance: 0,
+    heard: 23862017,
+    node: "GAYTO",
+    qset: {
+      t: 2,
+      v: ["SDF_validator_1", "SDF_validator_2", "SDF_validator_3"]
+    },
+    status: "tracking",
+    value: "[ txH: 7697aa, ct: 1557898494, upgrades: [ ] ]",
+    value_id: 1
+  },
+  {
+    distance: 1,
+    heard: 23862017,
+    node: "SDF_validator_3",
+    qset: {
+      t: 5,
+      v: [
+        "SDF_validator_3",
+        "SDF_validator_1",
+        "SDF_validator_2",
+        "LOBSTR_2__Europe_",
+        "Eno",
+        "umbrel",
+        "keybase_io",
+        "COINQVEST__Germany_",
+        {
+          t: 2,
+          v: [
+            "SatoshiPay__DE__Frankfurt_",
+            "SatoshiPay__SG__Singapore_",
+            "SatoshiPay__US__Iowa_"
+          ]
+        }
+      ]
+    },
+    status: "tracking",
+    value: "[ txH: 7697aa, ct: 1557898494, upgrades: [ ] ]",
+    value_id: 1
+  },
+  {
+    distance: 1,
+    heard: 23862017,
+    node: "SDF_validator_1",
+    qset: {
+      t: 5,
+      v: [
+        "SDF_validator_2",
+        "SDF_validator_3",
+        "Eno",
+        "LOBSTR_1__Europe_",
+        "keybase_io",
+        "umbrel",
+        "COINQVEST__Germany_",
+        {
+          t: 2,
+          v: ["Wirex_United_States", "Wirex_Singapore", "Wirex_United_Kingdom"]
+        },
+        {
+          t: 2,
+          v: [
+            "SatoshiPay__DE__Frankfurt_",
+            "SatoshiPay__SG__Singapore_",
+            "SatoshiPay__US__Iowa_"
+          ]
+        }
+      ]
+    },
+    status: "tracking",
+    value: "[ txH: 7697aa, ct: 1557898494, upgrades: [ ] ]",
+    value_id: 1
+  },
+  {
+    distance: 1,
+    heard: 23862017,
+    node: "SDF_validator_2",
+    qset: {
+      t: 5,
+      v: [
+        "SDF_validator_3",
+        "SDF_validator_1",
+        "SDF_validator_2",
+        "LOBSTR_2__Europe_",
+        "Eno",
+        "umbrel",
+        "keybase_io",
+        "COINQVEST__Finland_",
+        {
+          t: 2,
+          v: [
+            "SatoshiPay__DE__Frankfurt_",
+            "SatoshiPay__SG__Singapore_",
+            "SatoshiPay__US__Iowa_"
+          ]
+        }
+      ]
+    },
+    status: "tracking",
+    value: "[ txH: 7697aa, ct: 1557898494, upgrades: [ ] ]",
+    value_id: 1
+  },
+  {
+    distance: 2,
+    node: "Wirex_Singapore",
+    status: "missing"
+  },
+  {
+    distance: 2,
+    heard: 23862017,
+    node: "COINQVEST__Finland_",
+    qset: {
+      t: 6,
+      v: [
+        "COINQVEST__Germany_",
+        "COINQVEST__Finland_",
+        "keybase_io",
+        "LOBSTR_2__Europe_",
+        "Eno",
+        "umbrel",
+        {
+          t: 2,
+          v: [
+            "SatoshiPay__DE__Frankfurt_",
+            "SatoshiPay__SG__Singapore_",
+            "SatoshiPay__US__Iowa_"
+          ]
+        },
+        {
+          t: 2,
+          v: ["SDF_validator_1", "SDF_validator_2", "SDF_validator_3"]
+        }
+      ]
+    },
+    status: "tracking",
+    value: "[ txH: 7697aa, ct: 1557898494, upgrades: [ ] ]",
+    value_id: 1
+  },
+  {
+    distance: 2,
+    heard: 23862017,
+    node: "SatoshiPay__US__Iowa_",
+    qset: {
+      t: 5,
+      v: [
+        "COINQVEST__Germany_",
+        "LOBSTR_1__Europe_",
+        "SatoshiPay__DE__Frankfurt_",
+        "SatoshiPay__SG__Singapore_",
+        "SatoshiPay__US__Iowa_",
+        "umbrel",
+        {
+          t: 2,
+          v: ["SDF_validator_1", "SDF_validator_2", "SDF_validator_3"]
+        }
+      ]
+    },
+    status: "tracking",
+    value: "[ txH: 7697aa, ct: 1557898494, upgrades: [ ] ]",
+    value_id: 1
+  },
+  {
+    distance: 2,
+    heard: 23862017,
+    node: "Eno",
+    qset: {
+      t: 6,
+      v: [
+        "keybase_io",
+        "LOBSTR_2__Europe_",
+        "COINQVEST__Germany_",
+        "Eno",
+        "umbrel",
+        "IBM_Australia",
+        {
+          t: 2,
+          v: ["Wirex_United_States", "Wirex_Singapore", "Wirex_United_Kingdom"]
+        },
+        {
+          t: 2,
+          v: ["SDF_validator_1", "SDF_validator_2", "SDF_validator_3"]
+        },
+        {
+          t: 2,
+          v: [
+            "SatoshiPay__DE__Frankfurt_",
+            "SatoshiPay__SG__Singapore_",
+            "SatoshiPay__US__Iowa_"
+          ]
+        }
+      ]
+    },
+    status: "tracking",
+    value: "[ txH: 7697aa, ct: 1557898494, upgrades: [ ] ]",
+    value_id: 1
+  },
+  {
+    distance: 2,
+    heard: 23862017,
+    node: "Wirex_United_Kingdom",
+    qset: {
+      t: 7,
+      v: [
+        "keybase_io",
+        "LOBSTR_2__Europe_",
+        "Eno",
+        "umbrel",
+        "Wirex_United_States",
+        "Wirex_Singapore",
+        "Wirex_United_Kingdom",
+        {
+          t: 2,
+          v: ["SDF_validator_1", "SDF_validator_2", "SDF_validator_3"]
+        },
+        {
+          t: 2,
+          v: [
+            "SatoshiPay__DE__Frankfurt_",
+            "SatoshiPay__SG__Singapore_",
+            "SatoshiPay__US__Iowa_"
+          ]
+        }
+      ]
+    },
+    status: "tracking",
+    value: "[ txH: 7697aa, ct: 1557898494, upgrades: [ ] ]",
+    value_id: 1
+  },
+  {
+    distance: 2,
+    heard: 23862017,
+    node: "SatoshiPay__SG__Singapore_",
+    qset: {
+      t: 5,
+      v: [
+        "COINQVEST__Germany_",
+        "LOBSTR_1__Europe_",
+        "SatoshiPay__DE__Frankfurt_",
+        "SatoshiPay__SG__Singapore_",
+        "SatoshiPay__US__Iowa_",
+        "umbrel",
+        {
+          t: 2,
+          v: ["SDF_validator_1", "SDF_validator_2", "SDF_validator_3"]
+        }
+      ]
+    },
+    status: "tracking",
+    value: "[ txH: 7697aa, ct: 1557898494, upgrades: [ ] ]",
+    value_id: 1
+  },
+  {
+    distance: 2,
+    heard: 23862017,
+    node: "LOBSTR_1__Europe_",
+    qset: {
+      t: 7,
+      v: [
+        "LOBSTR_1__Europe_",
+        "LOBSTR_2__Europe_",
+        "keybase_io",
+        "COINQVEST__Germany_",
+        "Eno",
+        "umbrel",
+        {
+          t: 2,
+          v: ["Sakkex_Germany", "Sakkex_Singapore", "Sakkex_United_Kingdom"]
+        },
+        {
+          t: 2,
+          v: ["SDF_validator_1", "SDF_validator_2", "SDF_validator_3"]
+        },
+        {
+          t: 2,
+          v: ["Wirex_United_States", "Wirex_Singapore", "Wirex_United_Kingdom"]
+        },
+        {
+          t: 2,
+          v: [
+            "SatoshiPay__DE__Frankfurt_",
+            "SatoshiPay__SG__Singapore_",
+            "SatoshiPay__US__Iowa_"
+          ]
+        }
+      ]
+    },
+    status: "tracking",
+    value: "[ txH: 7697aa, ct: 1557898494, upgrades: [ ] ]",
+    value_id: 1
+  },
+  {
+    distance: 2,
+    heard: 23862017,
+    node: "keybase_io",
+    qset: {
+      t: 5,
+      v: [
+        "LOBSTR_2__Europe_",
+        "COINQVEST__Germany_",
+        "Eno",
+        "umbrel",
+        "IBM_Australia",
+        {
+          t: 2,
+          v: ["Sakkex_Germany", "Sakkex_Singapore", "Sakkex_United_Kingdom"]
+        },
+        {
+          t: 2,
+          v: ["Wirex_United_States", "Wirex_Singapore", "Wirex_United_Kingdom"]
+        },
+        {
+          t: 2,
+          v: [
+            "SatoshiPay__DE__Frankfurt_",
+            "SatoshiPay__SG__Singapore_",
+            "SatoshiPay__US__Iowa_"
+          ]
+        }
+      ]
+    },
+    status: "tracking",
+    value: "[ txH: 7697aa, ct: 1557898494, upgrades: [ ] ]",
+    value_id: 1
+  },
+  {
+    distance: 2,
+    heard: 23862017,
+    node: "SatoshiPay__DE__Frankfurt_",
+    qset: {
+      t: 5,
+      v: [
+        "COINQVEST__Germany_",
+        "LOBSTR_1__Europe_",
+        "SatoshiPay__DE__Frankfurt_",
+        "SatoshiPay__SG__Singapore_",
+        "SatoshiPay__US__Iowa_",
+        "umbrel",
+        {
+          t: 2,
+          v: ["SDF_validator_1", "SDF_validator_2", "SDF_validator_3"]
+        }
+      ]
+    },
+    status: "tracking",
+    value: "[ txH: 7697aa, ct: 1557898494, upgrades: [ ] ]",
+    value_id: 1
+  },
+  {
+    distance: 2,
+    heard: 23862017,
+    node: "LOBSTR_2__Europe_",
+    qset: {
+      t: 7,
+      v: [
+        "LOBSTR_1__Europe_",
+        "LOBSTR_2__Europe_",
+        "keybase_io",
+        "COINQVEST__Germany_",
+        "Eno",
+        "umbrel",
+        {
+          t: 2,
+          v: ["Sakkex_Germany", "Sakkex_Singapore", "Sakkex_United_Kingdom"]
+        },
+        {
+          t: 2,
+          v: ["SDF_validator_1", "SDF_validator_2", "SDF_validator_3"]
+        },
+        {
+          t: 2,
+          v: ["Wirex_United_States", "Wirex_Singapore", "Wirex_United_Kingdom"]
+        },
+        {
+          t: 2,
+          v: [
+            "SatoshiPay__DE__Frankfurt_",
+            "SatoshiPay__SG__Singapore_",
+            "SatoshiPay__US__Iowa_"
+          ]
+        }
+      ]
+    },
+    status: "tracking",
+    value: "[ txH: 7697aa, ct: 1557898494, upgrades: [ ] ]",
+    value_id: 1
+  },
+  {
+    distance: 2,
+    node: "Wirex_United_States",
+    qset: {
+      t: 7,
+      v: [
+        "keybase_io",
+        "LOBSTR_2__Europe_",
+        "Eno",
+        "umbrel",
+        "Wirex_United_States",
+        "Wirex_Singapore",
+        "Wirex_United_Kingdom",
+        {
+          t: 2,
+          v: ["SDF_validator_1", "SDF_validator_2", "SDF_validator_3"]
+        },
+        {
+          t: 2,
+          v: [
+            "SatoshiPay__DE__Frankfurt_",
+            "SatoshiPay__SG__Singapore_",
+            "SatoshiPay__US__Iowa_"
+          ]
+        }
+      ]
+    },
+    status: "missing"
+  },
+  {
+    distance: 2,
+    heard: 23862017,
+    node: "COINQVEST__Germany_",
+    qset: {
+      t: 6,
+      v: [
+        "COINQVEST__Germany_",
+        "COINQVEST__Finland_",
+        "keybase_io",
+        "LOBSTR_2__Europe_",
+        "Eno",
+        "umbrel",
+        {
+          t: 2,
+          v: [
+            "SatoshiPay__DE__Frankfurt_",
+            "SatoshiPay__SG__Singapore_",
+            "SatoshiPay__US__Iowa_"
+          ]
+        },
+        {
+          t: 2,
+          v: ["SDF_validator_1", "SDF_validator_2", "SDF_validator_3"]
+        }
+      ]
+    },
+    status: "tracking",
+    value: "[ txH: 7697aa, ct: 1557898494, upgrades: [ ] ]",
+    value_id: 1
+  },
+  {
+    distance: 2,
+    heard: 23862017,
+    node: "umbrel",
+    qset: {
+      t: 7,
+      v: [
+        "Eno",
+        "LOBSTR_2__Europe_",
+        "IBM_Australia",
+        "keybase_io",
+        "COINQVEST__Germany_",
+        "stellar_sui_li",
+        {
+          t: 2,
+          v: ["Sakkex_Germany", "Sakkex_Singapore", "Sakkex_United_Kingdom"]
+        },
+        {
+          t: 2,
+          v: ["Wirex_United_States", "Wirex_United_Kingdom", "Wirex_Singapore"]
+        },
+        {
+          t: 2,
+          v: [
+            "SatoshiPay__DE__Frankfurt_",
+            "SatoshiPay__SG__Singapore_",
+            "SatoshiPay__US__Iowa_"
+          ]
+        },
+        {
+          t: 2,
+          v: ["SDF_validator_1", "SDF_validator_2", "SDF_validator_3"]
+        }
+      ]
+    },
+    status: "tracking",
+    value: "[ txH: 7697aa, ct: 1557898494, upgrades: [ ] ]",
+    value_id: 1
+  },
+  {
+    distance: 3,
+    heard: 23862017,
+    node: "stellar_sui_li",
+    qset: {
+      t: 7,
+      v: [
+        "sui_li_testnode",
+        "keybase_io",
+        "Eno",
+        "umbrel",
+        "COINQVEST__Germany_",
+        "smoove_net_1",
+        "numerotron",
+        {
+          t: 2,
+          v: ["IBM_United_Kingdom", "IBM_Italy", "IBM_Hong_Kong"]
+        },
+        {
+          t: 2,
+          v: ["Wirex_United_States", "Wirex_Singapore", "Wirex_United_Kingdom"]
+        },
+        {
+          t: 2,
+          v: [
+            "SatoshiPay__DE__Frankfurt_",
+            "SatoshiPay__SG__Singapore_",
+            "SatoshiPay__US__Iowa_"
+          ]
+        }
+      ]
+    },
+    status: "tracking",
+    value: "[ txH: 7697aa, ct: 1557898494, upgrades: [ ] ]",
+    value_id: 1
+  },
+  {
+    distance: 3,
+    node: "Sakkex_Germany",
+    status: "missing"
+  },
+  {
+    distance: 3,
+    heard: 23862017,
+    node: "IBM_Australia",
+    qset: {
+      t: 3,
+      v: [
+        "keybase_io",
+        "LOBSTR_2__Europe_",
+        "Eno",
+        {
+          t: 2,
+          v: ["SDF_validator_1", "SDF_validator_2", "SDF_validator_3"]
+        },
+        {
+          t: 2,
+          v: [
+            "SatoshiPay__DE__Frankfurt_",
+            "SatoshiPay__SG__Singapore_",
+            "SatoshiPay__US__Iowa_"
+          ]
+        }
+      ]
+    },
+    status: "tracking",
+    value: "[ txH: 7697aa, ct: 1557898494, upgrades: [ ] ]",
+    value_id: 1
+  },
+  {
+    distance: 3,
+    node: "Sakkex_United_Kingdom",
+    status: "missing"
+  },
+  {
+    distance: 3,
+    node: "Sakkex_Singapore",
+    status: "missing"
+  },
+  {
+    distance: 4,
+    heard: 23862017,
+    node: "IBM_Italy",
+    qset: {
+      t: 5,
+      v: [
+        "keybase_io",
+        "LOBSTR_2__Europe_",
+        "Eno",
+        "umbrel",
+        {
+          t: 2,
+          v: [
+            "SatoshiPay__DE__Frankfurt_",
+            "SatoshiPay__SG__Singapore_",
+            "SatoshiPay__US__Iowa_"
+          ]
+        },
+        {
+          t: 2,
+          v: ["SDF_validator_1", "SDF_validator_2", "SDF_validator_3"]
+        },
+        {
+          t: 5,
+          v: [
+            "IBM_Australia",
+            "IBM_Brazil",
+            "IBM_Canada",
+            "IBM_Norway",
+            "IBM_India",
+            "IBM_Hong_Kong",
+            "IBM_United_Kingdom",
+            "IBM_United_States"
+          ]
+        }
+      ]
+    },
+    status: "tracking",
+    value: "[ txH: 7697aa, ct: 1557898494, upgrades: [ ] ]",
+    value_id: 1
+  },
+  {
+    distance: 4,
+    node: "IBM_United_Kingdom",
+    qset: {
+      t: 5,
+      v: [
+        "keybase_io",
+        "LOBSTR_2__Europe_",
+        "Eno",
+        "umbrel",
+        {
+          t: 2,
+          v: [
+            "SatoshiPay__DE__Frankfurt_",
+            "SatoshiPay__SG__Singapore_",
+            "SatoshiPay__US__Iowa_"
+          ]
+        },
+        {
+          t: 2,
+          v: ["SDF_validator_1", "SDF_validator_2", "SDF_validator_3"]
+        },
+        {
+          t: 5,
+          v: [
+            "IBM_Australia",
+            "IBM_Brazil",
+            "IBM_Canada",
+            "IBM_Italy",
+            "IBM_India",
+            "IBM_Hong_Kong",
+            "IBM_Norway",
+            "IBM_United_States"
+          ]
+        }
+      ]
+    },
+    status: "missing"
+  },
+  {
+    distance: 4,
+    heard: 23862017,
+    node: "IBM_Hong_Kong",
+    qset: {
+      t: 5,
+      v: [
+        "keybase_io",
+        "LOBSTR_2__Europe_",
+        "Eno",
+        "umbrel",
+        {
+          t: 2,
+          v: [
+            "SatoshiPay__DE__Frankfurt_",
+            "SatoshiPay__SG__Singapore_",
+            "SatoshiPay__US__Iowa_"
+          ]
+        },
+        {
+          t: 2,
+          v: ["SDF_validator_1", "SDF_validator_2", "SDF_validator_3"]
+        },
+        {
+          t: 5,
+          v: [
+            "IBM_Australia",
+            "IBM_Brazil",
+            "IBM_Norway",
+            "IBM_Italy",
+            "IBM_Canada",
+            "IBM_India",
+            "IBM_United_Kingdom",
+            "IBM_United_States"
+          ]
+        }
+      ]
+    },
+    status: "tracking",
+    value: "[ txH: 7697aa, ct: 1557898494, upgrades: [ ] ]",
+    value_id: 1
+  },
+  {
+    distance: 4,
+    node: "sui_li_testnode",
+    qset: {
+      t: 46,
+      v: [
+        "auskunft_de",
+        "Clic_World_3__Southern_Africa_",
+        "Stellarport_Ohio_1",
+        "Stellarport_Ohio_2",
+        "numerotron",
+        "SDF_validator_3",
+        "GCQKI",
+        "Sakkex_Germany",
+        "IBM_Australia",
+        "SDF_validator_2",
+        "Eno",
+        "COINQVEST__Germany_",
+        "Cryptomover_host_2",
+        "smoove_net_1",
+        "umbrel",
+        "SatoshiPay__US__Iowa_",
+        "GA76U",
+        "paywith_glass__Ireland_",
+        "IBM_Canada",
+        "Cryptomover_host_1",
+        "IBM_United_States",
+        "IBM_Italy",
+        "keybase_io",
+        "GBEPF",
+        "SDF_validator_1",
+        "Sakkex_United_Kingdom",
+        "COINQVEST__Finland_",
+        "GCUJF",
+        "Wirex_United_States",
+        "GBEJE",
+        "IBM_India",
+        "Smartlands_Platform",
+        "stellar_sui_li",
+        "SatoshiPay__DE__Frankfurt_",
+        "GCXLL",
+        "GANYY",
+        "IBM_Hong_Kong",
+        "Local_Stellar_Assets",
+        "Wirex_United_Kingdom",
+        "IBM_Brazil",
+        "Sakkex_Singapore",
+        "GBFSB",
+        "SatoshiPay__SG__Singapore_",
+        "Wirex_Singapore",
+        "WHITE_WALLET_1__USA_",
+        "GB4EK",
+        "LOBSTR_2__Europe_",
+        "Tempo",
+        "Mobius__United_States_",
+        "LOBSTR_1__Europe_",
+        "GDMAU",
+        "Tyler_Vault__Texas",
+        "IBM_United_Kingdom",
+        "GBIQ5",
+        "GCI5F",
+        "IBM_Norway",
+        "GAMX3",
+        "Cryptomover_host_3",
+        "Future",
+        "GAEJS",
+        "Clic_World_2__East_Africa_",
+        "GDRM4",
+        "GAJBH",
+        "GBCJ2",
+        "GBG67",
+        "KnackForge_LLC_US_1",
+        "GAUNZ",
+        "GAAZI"
+      ]
+    },
+    status: "missing"
+  },
+  {
+    distance: 4,
+    heard: 23862017,
+    node: "numerotron",
+    qset: {
+      t: 6,
+      v: [
+        "keybase_io",
+        "LOBSTR_2__Europe_",
+        "COINQVEST__Germany_",
+        "Eno",
+        "umbrel",
+        "IBM_Australia",
+        {
+          t: 2,
+          v: ["Sakkex_Germany", "Sakkex_Singapore", "Sakkex_United_Kingdom"]
+        },
+        {
+          t: 2,
+          v: ["Wirex_United_States", "Wirex_Singapore", "Wirex_United_Kingdom"]
+        },
+        {
+          t: 2,
+          v: [
+            "SatoshiPay__DE__Frankfurt_",
+            "SatoshiPay__SG__Singapore_",
+            "SatoshiPay__US__Iowa_"
+          ]
+        }
+      ]
+    },
+    status: "tracking",
+    value: "[ txH: 7697aa, ct: 1557898494, upgrades: [ ] ]",
+    value_id: 1
+  },
+  {
+    distance: 4,
+    heard: 23862017,
+    node: "smoove_net_1",
+    qset: {
+      t: 5,
+      v: [
+        "keybase_io",
+        "Smartlands_Platform",
+        "smoove_net_1",
+        "stellar_sui_li",
+        "umbrel",
+        {
+          t: 4,
+          v: [
+            "IBM_United_States",
+            "LOBSTR_1__Europe_",
+            "numerotron",
+            "Stellarport_Ohio_1",
+            "sui_li_testnode",
+            "Tyler_Vault__Texas",
+            "Wirex_United_States"
+          ]
+        },
+        {
+          t: 3,
+          v: [
+            "COINQVEST__Finland_",
+            "COINQVEST__Germany_",
+            "SatoshiPay__DE__Frankfurt_",
+            "SatoshiPay__SG__Singapore_",
+            "SatoshiPay__US__Iowa_"
+          ]
+        }
+      ]
+    },
+    status: "tracking",
+    value: "[ txH: 7697aa, ct: 1557898494, upgrades: [ ] ]",
+    value_id: 1
+  },
+  {
+    distance: 5,
+    heard: 23862017,
+    node: "GAAZI",
+    qset: {
+      t: 3,
+      v: [
+        "SDF_validator_1",
+        "SDF_validator_2",
+        "SDF_validator_3",
+        {
+          t: 3,
+          v: ["GDIQK", "Eno", "Tempo", "SatoshiPay__DE__Frankfurt_"]
+        }
+      ]
+    },
+    status: "tracking",
+    value: "[ txH: 7697aa, ct: 1557898494, upgrades: [ ] ]",
+    value_id: 1
+  },
+  {
+    distance: 5,
+    node: "GAEJS",
+    qset: {
+      t: 6,
+      v: [
+        "SDF_validator_1",
+        "SDF_validator_2",
+        "SDF_validator_3",
+        "SatoshiPay__DE__Frankfurt_",
+        "SatoshiPay__SG__Singapore_",
+        "SatoshiPay__US__Iowa_",
+        "IBM_Norway",
+        "IBM_Italy",
+        "IBM_United_Kingdom"
+      ]
+    },
+    status: "missing"
+  },
+  {
+    distance: 5,
+    node: "GAJBH",
+    qset: {
+      t: 3,
+      v: [
+        "SDF_validator_1",
+        "SDF_validator_2",
+        "SDF_validator_3",
+        {
+          t: 3,
+          v: ["GDIQK", "Eno", "Tempo", "SatoshiPay__DE__Frankfurt_"]
+        }
+      ]
+    },
+    status: "missing"
+  },
+  {
+    distance: 5,
+    node: "KnackForge_LLC_US_1",
+    qset: {
+      t: 4,
+      v: [
+        "SDF_validator_1",
+        "Eno",
+        "Tempo",
+        "SDF_validator_2",
+        "SDF_validator_3"
+      ]
+    },
+    status: "missing"
+  },
+  {
+    distance: 5,
+    heard: 23862017,
+    node: "GAMX3",
+    qset: {
+      t: 4,
+      v: [
+        "GAMX3",
+        "SatoshiPay__SG__Singapore_",
+        "Eno",
+        {
+          t: 2,
+          v: ["IBM_Australia", "IBM_India", "IBM_Hong_Kong"]
+        },
+        {
+          t: 2,
+          v: ["SDF_validator_1", "SDF_validator_2", "SDF_validator_3"]
+        }
+      ]
+    },
+    status: "tracking",
+    value: "[ txH: 7697aa, ct: 1557898494, upgrades: [ ] ]",
+    value_id: 1
+  },
+  {
+    distance: 5,
+    heard: 23862017,
+    node: "GANYY",
+    qset: {
+      t: 3,
+      v: [
+        "SDF_validator_1",
+        "SDF_validator_2",
+        "SDF_validator_3",
+        {
+          t: 3,
+          v: ["GDIQK", "Eno", "Tempo", "SatoshiPay__DE__Frankfurt_"]
+        }
+      ]
+    },
+    status: "tracking",
+    value: "[ txH: 7697aa, ct: 1557898494, upgrades: [ ] ]",
+    value_id: 1
+  },
+  {
+    distance: 5,
+    node: "IBM_United_States",
+    qset: {
+      t: 5,
+      v: [
+        "keybase_io",
+        "LOBSTR_2__Europe_",
+        "Eno",
+        "umbrel",
+        {
+          t: 2,
+          v: [
+            "SatoshiPay__DE__Frankfurt_",
+            "SatoshiPay__SG__Singapore_",
+            "SatoshiPay__US__Iowa_"
+          ]
+        },
+        {
+          t: 2,
+          v: ["SDF_validator_1", "SDF_validator_2", "SDF_validator_3"]
+        },
+        {
+          t: 5,
+          v: [
+            "IBM_Australia",
+            "IBM_Brazil",
+            "IBM_Canada",
+            "IBM_Italy",
+            "IBM_India",
+            "IBM_Hong_Kong",
+            "IBM_Norway",
+            "IBM_United_Kingdom"
+          ]
+        }
+      ]
+    },
+    status: "missing"
+  },
+  {
+    distance: 5,
+    node: "GAUNZ",
+    status: "missing"
+  },
+  {
+    distance: 5,
+    node: "Local_Stellar_Assets",
+    status: "missing"
+  },
+  {
+    distance: 5,
+    heard: 23862017,
+    node: "Tyler_Vault__Texas",
+    qset: {
+      t: 4,
+      v: [
+        "SDF_validator_1",
+        "Eno",
+        "Tempo",
+        "SDF_validator_2",
+        "SDF_validator_3"
+      ]
+    },
+    status: "tracking",
+    value: "[ txH: 7697aa, ct: 1557898494, upgrades: [ ] ]",
+    value_id: 1
+  },
+  {
+    distance: 5,
+    heard: 23862017,
+    node: "GA76U",
+    qset: {
+      t: 5,
+      v: [
+        "GBEPF",
+        "GA76U",
+        "IBM_Canada",
+        "IBM_United_Kingdom",
+        "IBM_Norway",
+        "SatoshiPay__DE__Frankfurt_",
+        "SatoshiPay__SG__Singapore_",
+        "SatoshiPay__US__Iowa_",
+        "SDF_validator_1",
+        "SDF_validator_2",
+        "SDF_validator_3"
+      ]
+    },
+    status: "tracking",
+    value: "[ txH: 7697aa, ct: 1557898494, upgrades: [ ] ]",
+    value_id: 1
+  },
+  {
+    distance: 5,
+    heard: 23862017,
+    node: "Stellarport_Ohio_1",
+    qset: {
+      t: 4,
+      v: [
+        "SDF_validator_1",
+        "SDF_validator_2",
+        "SDF_validator_3",
+        "SatoshiPay__US__Iowa_",
+        "Eno",
+        "Tempo"
+      ]
+    },
+    status: "tracking",
+    value: "[ txH: 7697aa, ct: 1557898494, upgrades: [ ] ]",
+    value_id: 1
+  },
+  {
+    distance: 5,
+    node: "Clic_World_3__Southern_Africa_",
+    status: "missing"
+  },
+  {
+    distance: 5,
+    heard: 23862017,
+    node: "GBCJ2",
+    qset: {
+      t: 3,
+      v: [
+        "SDF_validator_1",
+        "SDF_validator_2",
+        "SDF_validator_3",
+        {
+          t: 3,
+          v: ["GDIQK", "Eno", "Tempo", "SatoshiPay__DE__Frankfurt_"]
+        }
+      ]
+    },
+    status: "tracking",
+    value: "[ txH: 7697aa, ct: 1557898494, upgrades: [ ] ]",
+    value_id: 1
+  },
+  {
+    distance: 5,
+    heard: 23862017,
+    node: "GBEJE",
+    qset: {
+      t: 3,
+      v: [
+        "SDF_validator_1",
+        "SDF_validator_2",
+        "SDF_validator_3",
+        {
+          t: 3,
+          v: ["GDIQK", "Eno", "Tempo", "SatoshiPay__DE__Frankfurt_"]
+        }
+      ]
+    },
+    status: "tracking",
+    value: "[ txH: 7697aa, ct: 1557898494, upgrades: [ ] ]",
+    value_id: 1
+  },
+  {
+    distance: 5,
+    heard: 23862017,
+    node: "GBEPF",
+    qset: {
+      t: 5,
+      v: [
+        "GBEPF",
+        "GA76U",
+        "IBM_Canada",
+        "IBM_United_Kingdom",
+        "IBM_Norway",
+        "SatoshiPay__DE__Frankfurt_",
+        "SatoshiPay__SG__Singapore_",
+        "SatoshiPay__US__Iowa_",
+        "SDF_validator_1",
+        "SDF_validator_2",
+        "SDF_validator_3"
+      ]
+    },
+    status: "tracking",
+    value: "[ txH: 7697aa, ct: 1557898494, upgrades: [ ] ]",
+    value_id: 1
+  },
+  {
+    distance: 5,
+    heard: 23862017,
+    node: "GBFSB",
+    qset: {
+      t: 3,
+      v: [
+        "SDF_validator_1",
+        "SDF_validator_2",
+        "SDF_validator_3",
+        {
+          t: 3,
+          v: ["GDIQK", "Eno", "Tempo", "SatoshiPay__DE__Frankfurt_"]
+        }
+      ]
+    },
+    status: "tracking",
+    value: "[ txH: 7697aa, ct: 1557898494, upgrades: [ ] ]",
+    value_id: 1
+  },
+  {
+    distance: 5,
+    node: "Future",
+    qset: {
+      t: 3,
+      v: [
+        "Eno",
+        "SatoshiPay__DE__Frankfurt_",
+        "SatoshiPay__SG__Singapore_",
+        "SatoshiPay__US__Iowa_"
+      ]
+    },
+    status: "missing"
+  },
+  {
+    distance: 5,
+    node: "GBG67",
+    status: "missing"
+  },
+  {
+    distance: 5,
+    heard: 23862017,
+    node: "WHITE_WALLET_1__USA_",
+    qset: {
+      t: 4,
+      v: [
+        "SatoshiPay__DE__Frankfurt_",
+        "SatoshiPay__SG__Singapore_",
+        "SatoshiPay__US__Iowa_",
+        {
+          t: 5,
+          v: [
+            "IBM_Australia",
+            "IBM_Brazil",
+            "IBM_Canada",
+            "IBM_Norway",
+            "IBM_Italy",
+            "IBM_Hong_Kong",
+            "IBM_India",
+            "IBM_United_Kingdom",
+            "IBM_United_States"
+          ]
+        },
+        {
+          t: 2,
+          v: ["SDF_validator_1", "SDF_validator_2", "SDF_validator_3"]
+        }
+      ]
+    },
+    status: "tracking",
+    value: "[ txH: 7697aa, ct: 1557898494, upgrades: [ ] ]",
+    value_id: 1
+  },
+  {
+    distance: 5,
+    node: "GBIQ5",
+    status: "missing"
+  },
+  {
+    distance: 5,
+    heard: 23862017,
+    node: "auskunft_de",
+    qset: {
+      t: 3,
+      v: [
+        "SDF_validator_1",
+        "SDF_validator_2",
+        "SDF_validator_3",
+        {
+          t: 3,
+          v: ["auskunft_de", "LOBSTR_1__Europe_", "Eno", "Tempo"]
+        }
+      ]
+    },
+    status: "tracking",
+    value: "[ txH: 7697aa, ct: 1557898494, upgrades: [ ] ]",
+    value_id: 1
+  },
+  {
+    distance: 5,
+    node: "IBM_Brazil",
+    qset: {
+      t: 5,
+      v: [
+        "keybase_io",
+        "LOBSTR_2__Europe_",
+        "Eno",
+        "umbrel",
+        {
+          t: 2,
+          v: [
+            "SatoshiPay__DE__Frankfurt_",
+            "SatoshiPay__SG__Singapore_",
+            "SatoshiPay__US__Iowa_"
+          ]
+        },
+        {
+          t: 2,
+          v: ["SDF_validator_1", "SDF_validator_2", "SDF_validator_3"]
+        },
+        {
+          t: 5,
+          v: [
+            "IBM_Australia",
+            "IBM_Canada",
+            "IBM_Norway",
+            "IBM_Italy",
+            "IBM_Hong_Kong",
+            "IBM_India",
+            "IBM_United_Kingdom",
+            "IBM_United_States"
+          ]
+        }
+      ]
+    },
+    status: "missing"
+  },
+  {
+    distance: 5,
+    heard: 23862017,
+    node: "Cryptomover_host_1",
+    qset: {
+      t: 1,
+      v: ["SDF_validator_1", "SDF_validator_2", "SDF_validator_3"]
+    },
+    status: "tracking",
+    value: "[ txH: 7697aa, ct: 1557898494, upgrades: [ ] ]",
+    value_id: 1
+  },
+  {
+    distance: 5,
+    heard: 23862017,
+    node: "IBM_Canada",
+    qset: {
+      t: 5,
+      v: [
+        "keybase_io",
+        "LOBSTR_2__Europe_",
+        "Eno",
+        "umbrel",
+        {
+          t: 2,
+          v: [
+            "SatoshiPay__DE__Frankfurt_",
+            "SatoshiPay__SG__Singapore_",
+            "SatoshiPay__US__Iowa_"
+          ]
+        },
+        {
+          t: 2,
+          v: ["SDF_validator_1", "SDF_validator_2", "SDF_validator_3"]
+        },
+        {
+          t: 5,
+          v: [
+            "IBM_Australia",
+            "IBM_Brazil",
+            "IBM_Norway",
+            "IBM_Italy",
+            "IBM_Hong_Kong",
+            "IBM_India",
+            "IBM_United_Kingdom",
+            "IBM_United_States"
+          ]
+        }
+      ]
+    },
+    status: "tracking",
+    value: "[ txH: 7697aa, ct: 1557898494, upgrades: [ ] ]",
+    value_id: 1
+  },
+  {
+    distance: 5,
+    heard: 23862017,
+    node: "GB4EK",
+    qset: {
+      t: 4,
+      v: [
+        "SDF_validator_1",
+        "Eno",
+        "Tempo",
+        "SDF_validator_2",
+        "SDF_validator_3"
+      ]
+    },
+    status: "tracking",
+    value: "[ txH: 7697aa, ct: 1557898494, upgrades: [ ] ]",
+    value_id: 1
+  },
+  {
+    distance: 5,
+    heard: 23862012,
+    node: "Mobius__United_States_",
+    qset: {
+      t: 7,
+      v: [
+        "Eno",
+        "keybase_io",
+        "LOBSTR_1__Europe_",
+        "umbrel",
+        "Tempo",
+        {
+          t: 2,
+          v: ["SDF_validator_1", "SDF_validator_2", "SDF_validator_3"]
+        },
+        {
+          t: 2,
+          v: ["Wirex_United_States", "Wirex_Singapore", "Wirex_United_Kingdom"]
+        },
+        {
+          t: 2,
+          v: [
+            "SatoshiPay__DE__Frankfurt_",
+            "SatoshiPay__SG__Singapore_",
+            "SatoshiPay__US__Iowa_"
+          ]
+        },
+        {
+          t: 2,
+          v: ["Sakkex_Germany", "Sakkex_United_Kingdom", "Sakkex_Singapore"]
+        }
+      ]
+    },
+    status: "behind",
+    value: "[ txH: ba53d2, ct: 1557898452, upgrades: [ ] ]",
+    value_id: 55
+  },
+  {
+    distance: 5,
+    heard: 23862017,
+    node: "Smartlands_Platform",
+    qset: {
+      t: 6,
+      v: [
+        "GDIQK",
+        "Eno",
+        "Tempo",
+        "SatoshiPay__DE__Frankfurt_",
+        "umbrel",
+        "SDF_validator_1",
+        "SDF_validator_2",
+        "SDF_validator_3"
+      ]
+    },
+    status: "tracking",
+    value: "[ txH: 7697aa, ct: 1557898494, upgrades: [ ] ]",
+    value_id: 1
+  },
+  {
+    distance: 5,
+    heard: 23862006,
+    node: "IBM_India",
+    qset: {
+      t: 5,
+      v: [
+        "keybase_io",
+        "LOBSTR_2__Europe_",
+        "Eno",
+        "umbrel",
+        {
+          t: 2,
+          v: [
+            "SatoshiPay__DE__Frankfurt_",
+            "SatoshiPay__SG__Singapore_",
+            "SatoshiPay__US__Iowa_"
+          ]
+        },
+        {
+          t: 2,
+          v: ["SDF_validator_1", "SDF_validator_2", "SDF_validator_3"]
+        },
+        {
+          t: 5,
+          v: [
+            "IBM_Australia",
+            "IBM_Brazil",
+            "IBM_Canada",
+            "IBM_Norway",
+            "IBM_Italy",
+            "IBM_Hong_Kong",
+            "IBM_United_Kingdom",
+            "IBM_United_States"
+          ]
+        }
+      ]
+    },
+    status: "behind",
+    value: "[ txH: 75e05f, ct: 1557898455, upgrades: [ ] ]",
+    value_id: 57
+  },
+  {
+    distance: 5,
+    heard: 23862016,
+    node: "GCI5F",
+    qset: {
+      t: 6,
+      v: [
+        "GDIQK",
+        "Eno",
+        "Tempo",
+        "SatoshiPay__DE__Frankfurt_",
+        "umbrel",
+        "SDF_validator_1",
+        "SDF_validator_2",
+        "SDF_validator_3"
+      ]
+    },
+    status: "behind",
+    value: "[ txH: 5f8cd1, ct: 1557898485, upgrades: [ ] ]",
+    value_id: 58
+  },
+  {
+    distance: 5,
+    heard: 23862017,
+    node: "Tempo",
+    qset: {
+      t: 4,
+      v: [
+        "SDF_validator_2",
+        "SDF_validator_1",
+        "Tempo",
+        "Eno",
+        "SDF_validator_3"
+      ]
+    },
+    status: "tracking",
+    value: "[ txH: 7697aa, ct: 1557898494, upgrades: [ ] ]",
+    value_id: 1
+  },
+  {
+    distance: 5,
+    node: "GCQKI",
+    qset: {
+      t: 4,
+      v: [
+        "SDF_validator_1",
+        "IBM_United_States",
+        "keybase_io",
+        {
+          t: 3,
+          v: [
+            "GoodX_Network__DE_",
+            "Tempo",
+            {
+              t: 3,
+              v: [
+                "Mobius__United_States_",
+                "republic_co",
+                "SatoshiPay__DE__Frankfurt_",
+                "IBM_United_Kingdom"
+              ]
+            }
+          ]
+        },
+        {
+          t: 3,
+          v: ["GCQKI", "LOBSTR_1__Europe_", "SatoshiPay__US__Iowa_"]
+        }
+      ]
+    },
+    status: "missing"
+  },
+  {
+    distance: 5,
+    heard: 23862017,
+    node: "GCUJF",
+    qset: {
+      t: 4,
+      v: [
+        "GCUJF",
+        "SatoshiPay__DE__Frankfurt_",
+        "SatoshiPay__SG__Singapore_",
+        "SatoshiPay__US__Iowa_",
+        {
+          t: 5,
+          v: [
+            "IBM_Australia",
+            "IBM_Brazil",
+            "IBM_Canada",
+            "IBM_Norway",
+            "IBM_Italy",
+            "IBM_Hong_Kong",
+            "IBM_India",
+            "IBM_United_Kingdom",
+            "IBM_United_States"
+          ]
+        },
+        {
+          t: 2,
+          v: ["SDF_validator_1", "SDF_validator_2", "SDF_validator_3"]
+        }
+      ]
+    },
+    status: "tracking",
+    value: "[ txH: 7697aa, ct: 1557898494, upgrades: [ ] ]",
+    value_id: 1
+  },
+  {
+    distance: 5,
+    heard: 23862017,
+    node: "GCXLL",
+    qset: {
+      t: 7,
+      v: [
+        "GCXLL",
+        "Eno",
+        "SDF_validator_1",
+        "SDF_validator_2",
+        "SDF_validator_3",
+        "Mobius__United_States_",
+        "Smartlands_Platform",
+        "Stellarport_Ohio_1",
+        "Stronghold_3__Europe_"
+      ]
+    },
+    status: "tracking",
+    value: "[ txH: 7697aa, ct: 1557898494, upgrades: [ ] ]",
+    value_id: 1
+  },
+  {
+    distance: 5,
+    heard: 23862017,
+    node: "Cryptomover_host_3",
+    qset: {
+      t: 4,
+      v: [
+        "SDF_validator_1",
+        "Eno",
+        "Tempo",
+        "SDF_validator_2",
+        "SDF_validator_3"
+      ]
+    },
+    status: "tracking",
+    value: "[ txH: 7697aa, ct: 1557898494, upgrades: [ ] ]",
+    value_id: 1
+  },
+  {
+    distance: 5,
+    heard: 23862017,
+    node: "Stellarport_Ohio_2",
+    qset: {
+      t: 6,
+      v: [
+        "Tempo",
+        "SDF_validator_2",
+        "SDF_validator_3",
+        "LOBSTR_1__Europe_",
+        "Eno",
+        "SatoshiPay__US__Iowa_",
+        "COINQVEST__Germany_",
+        "LOBSTR_2__Europe_",
+        "SatoshiPay__DE__Frankfurt_"
+      ]
+    },
+    status: "tracking",
+    value: "[ txH: 7697aa, ct: 1557898494, upgrades: [ ] ]",
+    value_id: 1
+  },
+  {
+    distance: 5,
+    heard: 23862017,
+    node: "Cryptomover_host_2",
+    qset: {
+      t: 2,
+      v: [
+        "SDF_validator_1",
+        "SDF_validator_2",
+        "SDF_validator_3",
+        "Eno",
+        "Tempo",
+        "Mobius__United_States_",
+        "Cryptomover_host_1",
+        "Cryptomover_host_3"
+      ]
+    },
+    status: "tracking",
+    value: "[ txH: 7697aa, ct: 1557898494, upgrades: [ ] ]",
+    value_id: 1
+  },
+  {
+    distance: 5,
+    node: "Clic_World_2__East_Africa_",
+    status: "missing"
+  },
+  {
+    distance: 5,
+    heard: 23862017,
+    node: "GDMAU",
+    qset: {
+      t: 4,
+      v: [
+        "Eno",
+        "Mobius__United_States_",
+        {
+          t: 3,
+          v: [
+            "SatoshiPay__DE__Frankfurt_",
+            "SatoshiPay__SG__Singapore_",
+            "SatoshiPay__US__Iowa_"
+          ]
+        },
+        {
+          t: 4,
+          v: [
+            "IBM_Australia",
+            "IBM_Brazil",
+            "IBM_Canada",
+            "IBM_Norway",
+            "IBM_India",
+            "IBM_United_Kingdom",
+            "IBM_United_States"
+          ]
+        },
+        {
+          t: 3,
+          v: [
+            "keybase_io",
+            "Stellarport_Ohio_1",
+            "Stellarport_Ohio_2",
+            "Tempo",
+            "umbrel"
+          ]
+        },
+        {
+          t: 3,
+          v: ["SDF_validator_1", "SDF_validator_2", "SDF_validator_3"]
+        }
+      ]
+    },
+    status: "tracking",
+    value: "[ txH: 7697aa, ct: 1557898494, upgrades: [ ] ]",
+    value_id: 1
+  },
+  {
+    distance: 5,
+    heard: 23862016,
+    node: "paywith_glass__Ireland_",
+    qset: {
+      t: 12,
+      v: [
+        "Local_Stellar_Assets",
+        "SDF_validator_1",
+        "SDF_validator_2",
+        "SDF_validator_3",
+        "Eno",
+        "Tempo",
+        "keybase_io",
+        "umbrel",
+        "SatoshiPay__DE__Frankfurt_",
+        "SatoshiPay__SG__Singapore_",
+        "SatoshiPay__US__Iowa_",
+        "Cryptomover_host_1",
+        "Cryptomover_host_2",
+        "Cryptomover_host_3",
+        "IBM_United_Kingdom",
+        "IBM_Norway",
+        "IBM_Canada"
+      ]
+    },
+    status: "behind",
+    value: "[ txH: 4084d8, ct: 1557898486, upgrades: [ ] ]",
+    value_id: 68
+  },
+  {
+    distance: 5,
+    heard: 23862017,
+    node: "IBM_Norway",
+    qset: {
+      t: 5,
+      v: [
+        "keybase_io",
+        "LOBSTR_2__Europe_",
+        "Eno",
+        "umbrel",
+        {
+          t: 2,
+          v: [
+            "SatoshiPay__DE__Frankfurt_",
+            "SatoshiPay__SG__Singapore_",
+            "SatoshiPay__US__Iowa_"
+          ]
+        },
+        {
+          t: 2,
+          v: ["SDF_validator_1", "SDF_validator_2", "SDF_validator_3"]
+        },
+        {
+          t: 5,
+          v: [
+            "IBM_Australia",
+            "IBM_Brazil",
+            "IBM_Canada",
+            "IBM_Italy",
+            "IBM_India",
+            "IBM_Hong_Kong",
+            "IBM_United_Kingdom",
+            "IBM_United_States"
+          ]
+        }
+      ]
+    },
+    status: "tracking",
+    value: "[ txH: 7697aa, ct: 1557898494, upgrades: [ ] ]",
+    value_id: 1
+  },
+  {
+    distance: 5,
+    node: "GDRM4",
+    qset: {
+      t: 3,
+      v: [
+        "SDF_validator_1",
+        "SDF_validator_2",
+        "SDF_validator_3",
+        {
+          t: 3,
+          v: ["GDIQK", "Eno", "Tempo", "SatoshiPay__DE__Frankfurt_"]
+        }
+      ]
+    },
+    status: "missing"
+  },
+  {
+    distance: 6,
+    node: "GoodX_Network__DE_",
+    status: "missing"
+  },
+  {
+    distance: 6,
+    node: "republic_co",
+    status: "missing"
+  },
+  {
+    distance: 6,
+    node: "Stronghold_3__Europe_",
+    status: "missing"
+  },
+  {
+    distance: 6,
+    node: "GDIQK",
+    status: "missing"
+  }
+];
+
+export default nodes;

--- a/src/test/data/TwoNodeFailure.ts
+++ b/src/test/data/TwoNodeFailure.ts
@@ -1,0 +1,14 @@
+import { NetworkGraphNode } from "../../Types/NetworkTypes";
+import { makeGraph } from "../util/makeNode";
+
+// Failure when b and c go down
+const twonode: NetworkGraphNode[] = makeGraph({
+  a: {
+    distance: 0,
+    qset: { t: 1, v: ["b", "c"] }
+  },
+  b: {},
+  c: {}
+});
+
+export default twonode;

--- a/src/util/QuorumParsing.ts
+++ b/src/util/QuorumParsing.ts
@@ -22,7 +22,10 @@ export function networkNodesToGraphData(nodes: NetworkGraphNode[]): GraphData {
       }
     };
 
-    applyQuorumSetToNode(node, node.qset);
+    if (node.qset) {
+      applyQuorumSetToNode(node, node.qset);
+    }
+
     targetValidatorNames.forEach(target => {
       data.links.push({
         source: node.node,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2480,6 +2480,13 @@ browserslist@^4.0.0, browserslist@^4.1.1, browserslist@^4.4.2, browserslist@^4.5
     electron-to-chromium "^1.3.127"
     node-releases "^1.1.17"
 
+bs-logger@0.x:
+  version "0.2.6"
+  resolved "https://registry.yarnpkg.com/bs-logger/-/bs-logger-0.2.6.tgz#eb7d365307a72cf974cc6cda76b68354ad336bd8"
+  integrity sha512-pd8DCoxmbgc7hyPKOvxtqNcjYoOsABPQdcCUjGp3d42VR2CX1ORhk2A87oqqu5R1kk+76nsxZupkmyd+MVtCog==
+  dependencies:
+    fast-json-stable-stringify "2.x"
+
 bser@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/bser/-/bser-2.0.0.tgz#9ac78d3ed5d915804fd87acb158bc797147a1719"
@@ -2487,7 +2494,7 @@ bser@^2.0.0:
   dependencies:
     node-int64 "^0.4.0"
 
-buffer-from@^1.0.0:
+buffer-from@1.x, buffer-from@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.1.tgz#32713bc028f75c02fdb710d7c7bcec1f2c6070ef"
   integrity sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==
@@ -4418,7 +4425,7 @@ fast-glob@^2.0.2:
     merge2 "^1.2.3"
     micromatch "^3.1.10"
 
-fast-json-stable-stringify@^2.0.0:
+fast-json-stable-stringify@2.x, fast-json-stable-stringify@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz#d5142c0caee6b1189f87d3a76111064f86c8bbf2"
   integrity sha1-1RQsDK7msRifh9OnYREGT4bIu/I=
@@ -6249,17 +6256,17 @@ json3@^3.3.2:
   resolved "https://registry.yarnpkg.com/json3/-/json3-3.3.2.tgz#3c0434743df93e2f5c42aee7b19bcb483575f4e1"
   integrity sha1-PAQ0dD35Pi9cQq7nsZvLSDV19OE=
 
+json5@2.x, json5@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/json5/-/json5-2.1.0.tgz#e7a0c62c48285c628d20a10b85c89bb807c32850"
+  integrity sha512-8Mh9h6xViijj36g7Dxi+Y4S6hNGV96vcJZr/SrlHh1LR/pEn/8j/+qIBbs44YKl69Lrfctp4QD+AdWLTMqEZAQ==
+  dependencies:
+    minimist "^1.2.0"
+
 json5@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/json5/-/json5-1.0.1.tgz#779fb0018604fa854eacbf6252180d83543e3dbe"
   integrity sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==
-  dependencies:
-    minimist "^1.2.0"
-
-json5@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/json5/-/json5-2.1.0.tgz#e7a0c62c48285c628d20a10b85c89bb807c32850"
-  integrity sha512-8Mh9h6xViijj36g7Dxi+Y4S6hNGV96vcJZr/SrlHh1LR/pEn/8j/+qIBbs44YKl69Lrfctp4QD+AdWLTMqEZAQ==
   dependencies:
     minimist "^1.2.0"
 
@@ -6531,6 +6538,11 @@ make-dir@^2.0.0, make-dir@^2.1.0:
     pify "^4.0.1"
     semver "^5.6.0"
 
+make-error@1.x:
+  version "1.3.5"
+  resolved "https://registry.yarnpkg.com/make-error/-/make-error-1.3.5.tgz#efe4e81f6db28cadd605c70f29c831b58ef776c8"
+  integrity sha512-c3sIjNUow0+8swNwVpqoH4YCShKNFkMaw6oH1mNS2haDZQqkeZFlHS3dhoeEbKKmJB4vXpJucU6oH75aDYeE9g==
+
 makeerror@1.0.x:
   version "1.0.11"
   resolved "https://registry.yarnpkg.com/makeerror/-/makeerror-1.0.11.tgz#e01a5c9109f2af79660e4e8b9587790184f5a96c"
@@ -6781,7 +6793,7 @@ mixin-object@^2.0.1:
     for-in "^0.1.3"
     is-extendable "^0.1.1"
 
-mkdirp@0.5.1, mkdirp@0.5.x, mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5.0, mkdirp@~0.5.1:
+mkdirp@0.5.1, mkdirp@0.5.x, mkdirp@0.x, mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5.0, mkdirp@~0.5.1:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
   integrity sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=
@@ -8963,6 +8975,13 @@ resolve@1.10.0:
   dependencies:
     path-parse "^1.0.6"
 
+resolve@1.x:
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.11.1.tgz#ea10d8110376982fef578df8fc30b9ac30a07a3e"
+  integrity sha512-vIpgF6wfuJOZI7KKKSP+HmiKggadPQAdsp5HiC1mvqnfp0gF1vdwgBWZIdrVft9pgqoMFQN+R7BSWZiBxx+BBw==
+  dependencies:
+    path-parse "^1.0.6"
+
 resolve@^1.10.0, resolve@^1.3.2, resolve@^1.5.0, resolve@^1.8.1, resolve@^1.9.0:
   version "1.10.1"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.10.1.tgz#664842ac960795bbe758221cdccda61fb64b5f18"
@@ -9134,7 +9153,7 @@ semver-compare@^1.0.0:
   resolved "https://registry.yarnpkg.com/semver-compare/-/semver-compare-1.0.0.tgz#0dee216a1c941ab37e9efb1788f6afc5ff5537fc"
   integrity sha1-De4hahyUGrN+nvsXiPavxf9VN/w=
 
-"semver@2 || 3 || 4 || 5", semver@^5.3.0, semver@^5.4.1, semver@^5.5.0, semver@^5.5.1, semver@^5.6.0:
+"semver@2 || 3 || 4 || 5", semver@^5.3.0, semver@^5.4.1, semver@^5.5, semver@^5.5.0, semver@^5.5.1, semver@^5.6.0:
   version "5.7.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.0.tgz#790a7cf6fea5459bac96110b29b60412dc8ff96b"
   integrity sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==
@@ -9915,6 +9934,21 @@ trough@^1.0.0:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/trough/-/trough-1.0.3.tgz#e29bd1614c6458d44869fc28b255ab7857ef7c24"
   integrity sha512-fwkLWH+DimvA4YCy+/nvJd61nWQQ2liO/nF/RjkTpiOGi+zxZzVkhb1mvbHIIW4b/8nDsYI8uTmAlc0nNkRMOw==
+
+ts-jest@^24.0.2:
+  version "24.0.2"
+  resolved "https://registry.yarnpkg.com/ts-jest/-/ts-jest-24.0.2.tgz#8dde6cece97c31c03e80e474c749753ffd27194d"
+  integrity sha512-h6ZCZiA1EQgjczxq+uGLXQlNgeg02WWJBbeT8j6nyIBRQdglqbvzDoHahTEIiS6Eor6x8mK6PfZ7brQ9Q6tzHw==
+  dependencies:
+    bs-logger "0.x"
+    buffer-from "1.x"
+    fast-json-stable-stringify "2.x"
+    json5 "2.x"
+    make-error "1.x"
+    mkdirp "0.x"
+    resolve "1.x"
+    semver "^5.5"
+    yargs-parser "10.x"
 
 ts-pnp@1.1.2, ts-pnp@^1.0.0:
   version "1.1.2"
@@ -10725,7 +10759,7 @@ yallist@^3.0.0, yallist@^3.0.2:
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-3.0.3.tgz#b4b049e314be545e3ce802236d6cd22cd91c3de9"
   integrity sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==
 
-yargs-parser@^10.1.0:
+yargs-parser@10.x, yargs-parser@^10.1.0:
   version "10.1.0"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-10.1.0.tgz#7202265b89f7e9e9f2e5765e0fe735a905edbaa8"
   integrity sha512-VCIyR1wJoEBZUqk5PA+oOBF6ypbwh5aNB3I50guxAL/quggdfs4TtNHQrSazFA3fYZ+tEqfs0zIGlv0c/rgjbQ==


### PR DESCRIPTION
(built on top of #14 so don't review until that ones ready)

We need to check subsets of groups of nodes to see if 2 or 3 nodes can take down your network so extrapolate the tests to support n>1 max nodes.  Once we create all the combinations, the logic is the same: Iterate through the groupings of nodes instead of just individual nodes and take them down then check all their dependents to ensure we don't take down our root node.