### PR TITLE
Examine prehalt data in test and UI

### DIFF
--- a/src/Modules/quorum.ts
+++ b/src/Modules/quorum.ts
@@ -8,6 +8,7 @@ import healthy from "../test/data/HealthyQuorum";
 import highlyDependent from "../test/data/HighlyDependent";
 import { simple as highlyDependentSubquorum } from "../test/data/HighlyDependentSubquorum";
 import halfDead from "../test/data/HalfDead";
+import preHalt from "../test/data/PreHalt";
 
 const networkData = dummydata as { nodes: NetworkGraphNode[] };
 
@@ -15,7 +16,8 @@ type ExampleKey =
   | "healthy"
   | "halfDead"
   | "highlyDependent"
-  | "highlyDependentSubquorum";
+  | "highlyDependentSubquorum"
+  | "preHalt";
 
 type Action =
   | { type: "FETCH_QUORUM" }
@@ -34,7 +36,8 @@ const examples: Map<ExampleKey, NetworkGraphNode[]> = new Map([
   ["healthy", healthy],
   ["halfDead", halfDead],
   ["highlyDependent", highlyDependent],
-  ["highlyDependentSubquorum", highlyDependentSubquorum]
+  ["highlyDependentSubquorum", highlyDependentSubquorum],
+  ["preHalt", preHalt]
 ]);
 
 export function showExample(example: string): Action {
@@ -42,7 +45,7 @@ export function showExample(example: string): Action {
   if (!nodes) {
     throw new Error("Unknown example key");
   }
-  const failures = haltingAnalysis(nodes);
+  const failures = haltingAnalysis(nodes, 2);
   return { type: "USE_EXAMPLE", data: nodes, failures: failures };
 }
 

--- a/src/d3/ForceGraph.css
+++ b/src/d3/ForceGraph.css
@@ -6,10 +6,12 @@
 
 .node.dead {
   stroke: red;
+  fill: #fecccc;
 }
 
 .node[data-vulnerable="true"] {
   animation: nodepulse 1s ease-out infinite;
+  fill: white;
 }
 
 @keyframes nodepulse {
@@ -28,6 +30,10 @@
 
 .node.self + text {
   transform: translate(-9px, 7px);
+  font-size: 20px;
+}
+text {
+  font-size: 10px;
 }
 
 .link {

--- a/src/test/HaltingAnalysis.test.ts
+++ b/src/test/HaltingAnalysis.test.ts
@@ -1,7 +1,8 @@
 import {
   haltingAnalysis,
   createAnalysisStructure,
-  generateCombinations
+  generateCombinations,
+  HaltingFailure
 } from "../util/HaltingAnalysis";
 import healthy from "./data/HealthyQuorum";
 import healthySubquorums from "./data/HealthySubquorums";
@@ -10,6 +11,7 @@ import cyclical from "./data/CyclicalUnhealthy";
 import mixed from "./data/MixedQuorumType";
 import missing from "./data/MissingNodes";
 import twonode from "./data/TwoNodeFailure";
+import prehalt from "./data/PreHalt";
 import {
   simple as simpleSubquorum,
   complex as complexSubquorum
@@ -97,6 +99,15 @@ describe("halting analysis", () => {
     const nodes = ["a", "b", "c", "d", "e"];
     const sets = generateCombinations(nodes, 3);
     expect(sets).toHaveLength(25); // 5choose3 + 5choose2 + 5choose1 = 10 + 10 + 5
+  });
+
+  it("must find failure cases in PreHalt quorums", () => {
+    const fc = haltingAnalysis(prehalt, 2);
+    expect(fc).not.toHaveLength(0);
+    const sdfFailureCase = fc.find(failure => {
+      return !!failure.vulnerableNodes.find(n => n.node === "SDF_validator_1");
+    });
+    expect(sdfFailureCase).toBeDefined();
   });
 });
 

--- a/src/test/Quorum.test.ts
+++ b/src/test/Quorum.test.ts
@@ -1,5 +1,6 @@
 import { NetworkGraphNode, QuorumSet } from "../Types/NetworkTypes";
 import { networkNodesToGraphData } from "../util/QuorumParsing";
+import PreHalt from "./data/PreHalt";
 
 function makeNodeFromQset(qset: QuorumSet, opts?: any): NetworkGraphNode {
   return Object.assign(
@@ -80,6 +81,14 @@ describe("quorum parsing", () => {
       arrayContainingObject("target", "othervalidator1")
     );
     expect(data.links).toEqual(arrayContainingObject("target", "sdf_watcher1"));
+  });
+
+  it("should generate valid data from PreHalt snapshot", () => {
+    const data = networkNodesToGraphData(PreHalt);
+    data.links.forEach(l => {
+      expect(typeof l.source).toBe("string");
+      expect(typeof l.target).toBe("string");
+    });
   });
 });
 


### PR DESCRIPTION
Fixes graph data creation to handle mixed quorum types `(string | QuorumSet)[]` vs `string[] | QuorumSet[]`
bump the maxNodesToCheck to 2 so we actually find vulnerabilities.  This should probably be a slider in the UI which i can follow up with, and it will probably make all the example cases fail (as they all should, they were designed to be on the cusp).

Real networks are not the most readable things, so i want to ensure that this is valid failure set data, then figure out how to visualize it a bit cleaner

![Screenshot 2019-06-26 at 11 44 46 AM](https://user-images.githubusercontent.com/161135/60206342-24702380-9808-11e9-9506-b16058246528.png)
