### PR TITLE
Subset hiding

### DIFF
--- a/src/Components/ExamplePicker.tsx
+++ b/src/Components/ExamplePicker.tsx
@@ -20,7 +20,6 @@ const ExamplePicker = () => {
   }>(mapState);
 
   const onChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
-    console.log(e.target.value);
     if (e.target.value === "") return;
     dispatch(showExample(e.target.value));
   };

--- a/src/Modules/quorum.ts
+++ b/src/Modules/quorum.ts
@@ -47,7 +47,7 @@ export function showExample(example: string): Action {
   if (!nodes) {
     throw new Error("Unknown example key");
   }
-  const failures = haltingAnalysis(nodes, 2);
+  const failures = haltingAnalysis(nodes, 3);
   return {
     type: "USE_EXAMPLE",
     name: example,

--- a/src/test/HaltingAnalysis.test.ts
+++ b/src/test/HaltingAnalysis.test.ts
@@ -38,6 +38,14 @@ describe("halting analysis", () => {
     expect(affected).toContain("d");
   });
 
+  it("must not return supersets of existing failure cases", () => {
+    const failureCases = haltingAnalysis(highlyDependent, 2);
+    // Would return 7 if we were returning failure cases with e+something else
+    // expect e, b+c, b+d, c+d
+    // and filter out e+b, e+c, e+d
+    expect(failureCases).toHaveLength(4);
+  });
+
   it("must return failures for nested transitive quorum sets", () => {
     const failureCases = haltingAnalysis(simpleSubquorum);
     expect(failureCases).toHaveLength(1);

--- a/src/util/HaltingAnalysis.ts
+++ b/src/util/HaltingAnalysis.ts
@@ -138,6 +138,8 @@ export function haltingAnalysis(
   failureSets.forEach(nodesToHalt => {
     if (nodesToHalt.indexOf(root) !== -1) return;
 
+    // Don't search a node set if there's an existing failure case with a subset of these nodes.
+    // IE no need to test (NodeA U NodeB) for failure if we know (NodeA) alone will already cause it.
     if (
       failureCases.some(fc =>
         fc.vulnerableNodes.every(n =>

--- a/src/util/HaltingAnalysis.ts
+++ b/src/util/HaltingAnalysis.ts
@@ -114,7 +114,7 @@ export function generateCombinations<T>(items: T[], maxSize: number): (T[])[] {
     const otherCombos = generateCombinations(others, maxSize - 1);
     otherCombos.forEach(otherCombo => results.push([item, ...otherCombo]));
   });
-  return results;
+  return results.sort((a, b) => a.length - b.length);
 }
 
 /*
@@ -138,6 +138,15 @@ export function haltingAnalysis(
   failureSets.forEach(nodesToHalt => {
     if (nodesToHalt.indexOf(root) !== -1) return;
 
+    if (
+      failureCases.some(fc =>
+        fc.vulnerableNodes.every(n =>
+          nodesToHalt.some(an => an.networkObject === n)
+        )
+      )
+    ) {
+      return;
+    }
     reset(analysisNodes);
 
     let deadNodes: NetworkGraphNode[] = [];

--- a/src/util/QuorumParsing.ts
+++ b/src/util/QuorumParsing.ts
@@ -30,10 +30,6 @@ export function networkNodesToGraphData(nodes: NetworkGraphNode[]): GraphData {
     }
 
     targetValidatorNames.forEach(target => {
-      if (typeof target !== "string") {
-        console.log("Source", node.node);
-        console.log(target);
-      }
       data.links.push({
         source: node.node,
         target: target


### PR DESCRIPTION
Don't show failure sets that are supersets of smaller failure sets. If a+b causes a failure, there's no need to also return a+b+c, a+b+d, and a+b+c+d

also bump the max failure nodes to 3 to find more cases